### PR TITLE
Fix iOS 1.17 cost diagnostics and widget footer alignment

### DIFF
--- a/CodexBarMobile/CHANGELOG.md
+++ b/CodexBarMobile/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the CodexBar iOS companion app will be documented in this file.
 
+## [1.17.0 (183)] — 2026-07-07 — Cost diagnostics and widget footer follow-up
+
+### Added
+
+- **Cost Diagnostics** — Added a Developer Tools audit page that shows the
+  Cost source path, 90-day/active-day summary, provider merge rules,
+  reconciliation checks for Overview / Provider Share / Daily Spend / Model Mix
+  / Codex Service Mix / share cards, and a link back to Raw Sync Data for source
+  inspection.
+
+### Changed
+
+- **Local cost history default** — Local Cost History now defaults on with a
+  90-day window. Cost Settings explains that OFF uses synced Mac snapshots and
+  the Mac history window, while ON keeps synced daily cost points locally on
+  iPhone for the selected window.
+
+### Fixed
+
+- **Widget footer alignment** — The "Updated just now" footer is centered for
+  every widget mode and supported widget family, not only selected Today Cost
+  layouts.
+
+### Notes
+
+- iOS-only follow-up on the `1.17.0` line; `MARKETING_VERSION` remains
+  `1.17.0`.
+- iOS `CURRENT_PROJECT_VERSION`: `182` → `183`.
+
+---
+
 ## [1.17.0 (182)] — 2026-07-06 — Cost data integrity hotfix
 
 ### Fixed

--- a/CodexBarMobile/CHANGELOG.md
+++ b/CodexBarMobile/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the CodexBar iOS companion app will be documented in this file.
 
-## [1.17.0 (183)] — 2026-07-07 — Cost diagnostics and widget footer follow-up
+## [1.17.0 (185)] — 2026-07-07 — Cost diagnostics and widget footer follow-up
 
 ### Added
 
@@ -29,7 +29,7 @@ All notable changes to the CodexBar iOS companion app will be documented in this
 
 - iOS-only follow-up on the `1.17.0` line; `MARKETING_VERSION` remains
   `1.17.0`.
-- iOS `CURRENT_PROJECT_VERSION`: `182` → `183`.
+- iOS `CURRENT_PROJECT_VERSION`: `182` → `185`.
 
 ---
 

--- a/CodexBarMobile/CodexBarMobile.xcodeproj/project.pbxproj
+++ b/CodexBarMobile/CodexBarMobile.xcodeproj/project.pbxproj
@@ -1230,7 +1230,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobileWidgets/WidgetExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 183;
+				CURRENT_PROJECT_VERSION = 184;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobileWidgets/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1250,7 +1250,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 183;
+				CURRENT_PROJECT_VERSION = 184;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1275,7 +1275,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobileWidgets/WidgetExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 183;
+				CURRENT_PROJECT_VERSION = 184;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobileWidgets/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1450,7 +1450,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobilePushExtension/PushExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 183;
+				CURRENT_PROJECT_VERSION = 184;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobilePushExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1472,7 +1472,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobile/CodexBarMobile.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 183;
+				CURRENT_PROJECT_VERSION = 184;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1510,7 +1510,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobile/CodexBarMobile.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 183;
+				CURRENT_PROJECT_VERSION = 184;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1546,7 +1546,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 183;
+				CURRENT_PROJECT_VERSION = 184;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1570,7 +1570,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobilePushExtension/PushExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 183;
+				CURRENT_PROJECT_VERSION = 184;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobilePushExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/CodexBarMobile/CodexBarMobile.xcodeproj/project.pbxproj
+++ b/CodexBarMobile/CodexBarMobile.xcodeproj/project.pbxproj
@@ -116,6 +116,8 @@
 		9A1752C4414B06CE642241FB /* CodexBarSync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D34FB83FA26B8508F5A3D9FB /* CodexBarSync.framework */; };
 		9C00DB027AB6C29845327154 /* CWLWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0629321562B420C752FB0A8 /* CWLWriterTests.swift */; };
 		A107A3ED4961AA8B614D11BE /* SubscriptionUtilizationCompatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D15EF2654204A9652A1F59F /* SubscriptionUtilizationCompatTests.swift */; };
+		A20347E744A9E2CFB5EC511F /* CostDiagnosticsReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E83B0C98E9E8AD54885EA6C3 /* CostDiagnosticsReportTests.swift */; };
+		A2293BFA659785CCAF61C30B /* CostDiagnosticsReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE097409AB03C48BF5C1524C /* CostDiagnosticsReport.swift */; };
 		A24E829408C379D88C7715CC /* ProviderColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637E4394D6D0E0F76AFD654A /* ProviderColorPalette.swift */; };
 		A644FDE234CC676EC59CC891 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F8B2EE4A4A283389BC42245 /* ContentView.swift */; };
 		A7A9772DEE62BDA0E16FC91E /* AccountIdentityMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E315BCDE160D8764FE14F2 /* AccountIdentityMergeTests.swift */; };
@@ -376,6 +378,7 @@
 		BC74955D108073474BBBAB91 /* CWLMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CWLMigrationTests.swift; sourceTree = "<group>"; };
 		BC8893A8B73134178D35F274 /* CloudKitMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitMergeTests.swift; sourceTree = "<group>"; };
 		BCE6CB7DCBC0976E4414C63D /* V029Snapshots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V029Snapshots.swift; sourceTree = "<group>"; };
+		BE097409AB03C48BF5C1524C /* CostDiagnosticsReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CostDiagnosticsReport.swift; sourceTree = "<group>"; };
 		C1DABA431C3A96BC06782271 /* ModelContainerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelContainerFactoryTests.swift; sourceTree = "<group>"; };
 		C39869539C7AAD1E71CCEDD6 /* V026SettingsTogglesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V026SettingsTogglesTests.swift; sourceTree = "<group>"; };
 		C3D273F51CDB63F11D2E772A /* QuotaProviderListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotaProviderListTests.swift; sourceTree = "<group>"; };
@@ -405,6 +408,7 @@
 		E51BEDB997C80D4064449061 /* SnapshotCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotCache.swift; sourceTree = "<group>"; };
 		E53728795F865E33900DA3C3 /* CodexBarMobileUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexBarMobileUITests.swift; sourceTree = "<group>"; };
 		E61A19B110DF384F7EE02BD5 /* DeviceSnapshotResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceSnapshotResolver.swift; sourceTree = "<group>"; };
+		E83B0C98E9E8AD54885EA6C3 /* CostDiagnosticsReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CostDiagnosticsReportTests.swift; sourceTree = "<group>"; };
 		E8C6050FE3CCE339F505DF43 /* GrokBillingCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrokBillingCard.swift; sourceTree = "<group>"; };
 		F06B5BB1489F508FCD20228A /* DualZoneReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DualZoneReaderTests.swift; sourceTree = "<group>"; };
 		F1706346D05559DDD5AA66F0 /* CodexBarMobileTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = CodexBarMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -481,6 +485,7 @@
 				247726F710DF2854B553518D /* ClaudePeakHoursTests.swift */,
 				BC8893A8B73134178D35F274 /* CloudKitMergeTests.swift */,
 				870084949E272491E62DA97A /* CodexBarWidgetRenderMatrixTests.swift */,
+				E83B0C98E9E8AD54885EA6C3 /* CostDiagnosticsReportTests.swift */,
 				3786C6898A111474E86E69D7 /* CostFormattingTests.swift */,
 				4711C2FDFCB5E5A666E793D0 /* CostShareServiceTests.swift */,
 				A4CAFB868825B9A3F09FE0AA /* DeviceLifecycleEventTests.swift */,
@@ -710,6 +715,7 @@
 			isa = PBXGroup;
 			children = (
 				646750577DC086F6AB6026FD /* ClaudePeakHours.swift */,
+				BE097409AB03C48BF5C1524C /* CostDiagnosticsReport.swift */,
 				947901EA2B0C4A99FF204533 /* CostFormatting.swift */,
 				6C72A51985FA627302CDAC57 /* CostShareService.swift */,
 				252CB6CF0CDF983CD183384F /* MobileChartAxisFormatter.swift */,
@@ -999,6 +1005,7 @@
 				2F95648D7B6137DC85B62F37 /* ClaudePeakHoursTests.swift in Sources */,
 				B0BD7B9F90964EE0B5859675 /* CloudKitMergeTests.swift in Sources */,
 				8A91B1F478834F5321289410 /* CodexBarWidgetRenderMatrixTests.swift in Sources */,
+				A20347E744A9E2CFB5EC511F /* CostDiagnosticsReportTests.swift in Sources */,
 				BF62F92B51A09BA238F46145 /* CostFormattingTests.swift in Sources */,
 				7FE9B2381025A654D758FD62 /* CostShareServiceTests.swift in Sources */,
 				FD2364635784A71AE994402E /* DeviceLifecycleEventTests.swift in Sources */,
@@ -1055,6 +1062,7 @@
 				A9BDE220C1106C420FCBECAF /* CodexResetCreditsCard.swift in Sources */,
 				33F818074F133935C89B4097 /* CodexWorkspaceBadge.swift in Sources */,
 				A644FDE234CC676EC59CC891 /* ContentView.swift in Sources */,
+				A2293BFA659785CCAF61C30B /* CostDiagnosticsReport.swift in Sources */,
 				ACA7EB9D06944B5EA0FD9E84 /* CostFormatting.swift in Sources */,
 				82D12B778494DEEFDCB40A06 /* CostLedgerModels.swift in Sources */,
 				53E21E78D165FB4E038BA2FF /* CostLedgerService.swift in Sources */,
@@ -1218,7 +1226,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobileWidgets/WidgetExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 182;
+				CURRENT_PROJECT_VERSION = 183;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobileWidgets/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1238,7 +1246,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 182;
+				CURRENT_PROJECT_VERSION = 183;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1263,7 +1271,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobileWidgets/WidgetExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 182;
+				CURRENT_PROJECT_VERSION = 183;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobileWidgets/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1438,7 +1446,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobilePushExtension/PushExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 182;
+				CURRENT_PROJECT_VERSION = 183;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobilePushExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1460,7 +1468,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobile/CodexBarMobile.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 182;
+				CURRENT_PROJECT_VERSION = 183;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1498,7 +1506,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobile/CodexBarMobile.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 182;
+				CURRENT_PROJECT_VERSION = 183;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1534,7 +1542,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 182;
+				CURRENT_PROJECT_VERSION = 183;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1558,7 +1566,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobilePushExtension/PushExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 182;
+				CURRENT_PROJECT_VERSION = 183;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobilePushExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/CodexBarMobile/CodexBarMobile.xcodeproj/project.pbxproj
+++ b/CodexBarMobile/CodexBarMobile.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		77CF9F560A2873DDC19B0A3D /* QuotaTransitionSubscriptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDEAEEF583AFDE3D29A18C3 /* QuotaTransitionSubscriptionsTests.swift */; };
 		78A8D4ECC85D519DB04C6B07 /* DeepgramUsageCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA293C8F7A388B3FE79C2856 /* DeepgramUsageCard.swift */; };
 		7921A012D44F975F8AFC63DE /* CostShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8515047932479670A9749119 /* CostShareSheet.swift */; };
+		79CB19B99E02908405F7DA54 /* CostTabInsightsResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA78FB043B1F158AEA970465 /* CostTabInsightsResolverTests.swift */; };
 		7FE9B2381025A654D758FD62 /* CostShareServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4711C2FDFCB5E5A666E793D0 /* CostShareServiceTests.swift */; };
 		80B6863B91547B2CA369FC58 /* WidgetSnapshotBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534FD5DA53F564D357F039EE /* WidgetSnapshotBuilderTests.swift */; };
 		82D12B778494DEEFDCB40A06 /* CostLedgerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CA4E5C7B1091C018B038D4 /* CostLedgerModels.swift */; };
@@ -417,6 +418,7 @@
 		F73457F32FC7DD4C6DE7F847 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		F74DC452F05CFF7BC6196E10 /* WidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WidgetExtension.entitlements; sourceTree = "<group>"; };
 		FA73FB0C58DB34861BD5E35F /* ProviderUsageSnapshot+Identity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProviderUsageSnapshot+Identity.swift"; sourceTree = "<group>"; };
+		FA78FB043B1F158AEA970465 /* CostTabInsightsResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CostTabInsightsResolverTests.swift; sourceTree = "<group>"; };
 		FD8478C8A0C9D8732B72F7CB /* CodexWorkspaceBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexWorkspaceBadge.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -488,6 +490,7 @@
 				E83B0C98E9E8AD54885EA6C3 /* CostDiagnosticsReportTests.swift */,
 				3786C6898A111474E86E69D7 /* CostFormattingTests.swift */,
 				4711C2FDFCB5E5A666E793D0 /* CostShareServiceTests.swift */,
+				FA78FB043B1F158AEA970465 /* CostTabInsightsResolverTests.swift */,
 				A4CAFB868825B9A3F09FE0AA /* DeviceLifecycleEventTests.swift */,
 				F06B5BB1489F508FCD20228A /* DualZoneReaderTests.swift */,
 				DCEB2C9879BAEC3DF4AEAB41 /* LinkageRecordMergeTests.swift */,
@@ -1008,6 +1011,7 @@
 				A20347E744A9E2CFB5EC511F /* CostDiagnosticsReportTests.swift in Sources */,
 				BF62F92B51A09BA238F46145 /* CostFormattingTests.swift in Sources */,
 				7FE9B2381025A654D758FD62 /* CostShareServiceTests.swift in Sources */,
+				79CB19B99E02908405F7DA54 /* CostTabInsightsResolverTests.swift in Sources */,
 				FD2364635784A71AE994402E /* DeviceLifecycleEventTests.swift in Sources */,
 				37D05E7A04ABF89129C7D284 /* DualZoneReaderTests.swift in Sources */,
 				F97B630E810DB48A4CB150C7 /* LinkageRecordMergeTests.swift in Sources */,

--- a/CodexBarMobile/CodexBarMobile.xcodeproj/project.pbxproj
+++ b/CodexBarMobile/CodexBarMobile.xcodeproj/project.pbxproj
@@ -1230,7 +1230,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobileWidgets/WidgetExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 184;
+				CURRENT_PROJECT_VERSION = 185;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobileWidgets/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1250,7 +1250,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 184;
+				CURRENT_PROJECT_VERSION = 185;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1275,7 +1275,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobileWidgets/WidgetExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 184;
+				CURRENT_PROJECT_VERSION = 185;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobileWidgets/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1450,7 +1450,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobilePushExtension/PushExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 184;
+				CURRENT_PROJECT_VERSION = 185;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobilePushExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1472,7 +1472,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobile/CodexBarMobile.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 184;
+				CURRENT_PROJECT_VERSION = 185;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1510,7 +1510,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobile/CodexBarMobile.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 184;
+				CURRENT_PROJECT_VERSION = 185;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1546,7 +1546,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 184;
+				CURRENT_PROJECT_VERSION = 185;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1570,7 +1570,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobilePushExtension/PushExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 184;
+				CURRENT_PROJECT_VERSION = 185;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobilePushExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -418,7 +418,7 @@ private struct CostTab: View {
         // no ledger). `try?` falls back to the blob path on any ledger error.
         if self.cwlEnabled,
            !self.isDemoMode,
-           let aggregation = try? CostLedgerService.aggregate(
+           let aggregation = try? CostLedgerService.aggregateSeedingFromExistingBlobsIfNeeded(
                windowDays: self.cwlWindowDays,
                in: self.modelContext,
                activeDeviceIDs: self.activeDeviceIDsForLedger)
@@ -2833,7 +2833,7 @@ private struct CostDiagnosticsView: View {
     private var report: CostDiagnosticsReport? {
         guard let snapshot = self.usageData.snapshot else { return nil }
         let aggregation = self.cwlEnabled
-            ? try? CostLedgerService.aggregate(
+            ? try? CostLedgerService.aggregateSeedingFromExistingBlobsIfNeeded(
                 windowDays: self.cwlWindowDays,
                 in: self.modelContext,
                 activeDeviceIDs: self.activeDeviceIDsForLedger)

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -456,6 +456,8 @@ private struct CostTab: View {
     let usageData: SyncedUsageData
     @Binding var isDemoMode: Bool
     @State private var showShareSheet = false
+    @State private var cachedLedgerSignature: String?
+    @State private var cachedLedgerAggregation: CostLedgerAggregation?
 
     // Round 6 / P4b — Cost Window Ledger dispatch. When `cwlEnabled` and not
     // in demo mode, the dashboard reads the ledger (re-windowed by
@@ -478,15 +480,8 @@ private struct CostTab: View {
     /// Synchronous compute ensures first render has data for UI tests and user-perceived responsiveness.
     private var currentInsights: CostDashboardInsights? {
         guard let snapshot = self.displaySnapshot else { return nil }
-        // CWL path only outside demo mode (demo uses a synthetic snapshot with
-        // no ledger). A missing aggregation falls back to the blob path, while
-        // an intentionally empty ledger after Clear Local Cost History stays
-        // empty instead of rebuilding stale costs from synced blobs.
-        let aggregation = self.cwlEnabled && !self.isDemoMode
-            ? try? CostLedgerService.aggregateSeedingFromExistingBlobsIfNeeded(
-               windowDays: self.cwlWindowDays,
-               in: self.modelContext,
-               activeDeviceIDs: self.activeDeviceIDsForLedger)
+        let aggregation = self.shouldUseLedger && self.cachedLedgerSignature == self.ledgerRefreshSignature
+            ? self.cachedLedgerAggregation
             : nil
         return CostTabInsightsResolver.make(
             snapshot: snapshot,
@@ -498,6 +493,45 @@ private struct CostTab: View {
 
     private var activeDeviceIDsForLedger: Set<String>? {
         CostLedgerDeviceFilter.activeDeviceIDs(for: self.usageData.deviceSnapshots)
+    }
+
+    private var shouldUseLedger: Bool {
+        self.cwlEnabled && !self.isDemoMode
+    }
+
+    private var ledgerRefreshSignature: String {
+        guard self.shouldUseLedger else {
+            return "off"
+        }
+        let activeDeviceIDs = self.activeDeviceIDsForLedger?.sorted().joined(separator: ",") ?? "_"
+        let latestSync = self.usageData.deviceSnapshots
+            .map(\.syncTimestamp.timeIntervalSince1970)
+            .max() ?? 0
+        let latestProviderUpdate = self.usageData.deviceSnapshots
+            .flatMap { $0.providers.map(\.lastUpdated.timeIntervalSince1970) }
+            .max() ?? 0
+        let providerCount = self.usageData.deviceSnapshots.reduce(0) { $0 + $1.providers.count }
+        return [
+            "\(self.cwlWindowDays)",
+            activeDeviceIDs,
+            "\(latestSync)",
+            "\(latestProviderUpdate)",
+            "\(providerCount)",
+        ].joined(separator: "|")
+    }
+
+    @MainActor
+    private func refreshLedgerAggregation(for signature: String) {
+        guard self.shouldUseLedger else {
+            self.cachedLedgerSignature = signature
+            self.cachedLedgerAggregation = nil
+            return
+        }
+        self.cachedLedgerAggregation = try? CostLedgerService.aggregateSeedingFromExistingBlobsIfNeeded(
+            windowDays: self.cwlWindowDays,
+            in: self.modelContext,
+            activeDeviceIDs: self.activeDeviceIDsForLedger)
+        self.cachedLedgerSignature = signature
     }
 
     var body: some View {
@@ -546,6 +580,9 @@ private struct CostTab: View {
                 if let insights = self.currentInsights {
                     CostShareSheet(insights: insights)
                 }
+            }
+            .task(id: self.ledgerRefreshSignature) {
+                self.refreshLedgerAggregation(for: self.ledgerRefreshSignature)
             }
         }
     }
@@ -2902,7 +2939,7 @@ private struct CostDiagnosticsView: View {
     private var report: CostDiagnosticsReport? {
         guard let snapshot = self.usageData.snapshot else { return nil }
         let aggregation = self.cwlEnabled
-            ? try? CostLedgerService.aggregateSeedingFromExistingBlobsIfNeeded(
+            ? try? CostLedgerService.aggregate(
                 windowDays: self.cwlWindowDays,
                 in: self.modelContext,
                 activeDeviceIDs: self.activeDeviceIDsForLedger)

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -2903,6 +2903,9 @@ private struct CostDiagnosticsView: View {
     @Environment(\.modelContext) private var modelContext
     @AppStorage(MobileSettingsKeys.cwlEnabled) private var cwlEnabled = MobileSettingsDefaults.cwlEnabled
     @AppStorage(MobileSettingsKeys.cwlWindowDays) private var cwlWindowDays = MobileSettingsDefaults.cwlWindowDays
+    @AppStorage(MobileSettingsKeys.cwlBlobSeedClearedAt) private var cwlBlobSeedClearedAt: Double = 0
+    @State private var cachedLedgerSignature: String?
+    @State private var cachedLedgerAggregation: CostLedgerAggregation?
 
     var body: some View {
         List {
@@ -2975,15 +2978,16 @@ private struct CostDiagnosticsView: View {
             }
         }
         .navigationTitle("Cost Diagnostics")
+        .task(id: self.ledgerRefreshSignature) {
+            self.refreshLedgerAggregation(for: self.ledgerRefreshSignature)
+        }
     }
 
     private var report: CostDiagnosticsReport? {
         guard let snapshot = self.usageData.snapshot else { return nil }
-        let aggregation = CostDiagnosticsLedgerAggregationResolver.make(
-            cwlEnabled: self.cwlEnabled,
-            cwlWindowDays: self.cwlWindowDays,
-            modelContext: self.modelContext,
-            activeDeviceIDs: self.activeDeviceIDsForLedger)
+        let aggregation = self.cwlEnabled && self.cachedLedgerSignature == self.ledgerRefreshSignature
+            ? self.cachedLedgerAggregation
+            : nil
 
         return CostDiagnosticsReportResolver.make(
             snapshot: snapshot,
@@ -2997,6 +3001,43 @@ private struct CostDiagnosticsView: View {
 
     private var activeDeviceIDsForLedger: Set<String>? {
         CostLedgerDeviceFilter.activeDeviceIDs(for: self.usageData.deviceSnapshots)
+    }
+
+    private var ledgerRefreshSignature: String {
+        guard self.cwlEnabled else {
+            return "off"
+        }
+        let activeDeviceIDs = self.activeDeviceIDsForLedger?.sorted().joined(separator: ",") ?? "_"
+        let latestSync = self.usageData.deviceSnapshots
+            .map(\.syncTimestamp.timeIntervalSince1970)
+            .max() ?? 0
+        let latestProviderUpdate = self.usageData.deviceSnapshots
+            .flatMap { $0.providers.map(\.lastUpdated.timeIntervalSince1970) }
+            .max() ?? 0
+        let providerCount = self.usageData.deviceSnapshots.reduce(0) { $0 + $1.providers.count }
+        return [
+            "\(self.cwlWindowDays)",
+            activeDeviceIDs,
+            "\(latestSync)",
+            "\(latestProviderUpdate)",
+            "\(providerCount)",
+            "\(self.cwlBlobSeedClearedAt)",
+        ].joined(separator: "|")
+    }
+
+    @MainActor
+    private func refreshLedgerAggregation(for signature: String) {
+        guard self.cwlEnabled else {
+            self.cachedLedgerSignature = signature
+            self.cachedLedgerAggregation = nil
+            return
+        }
+        self.cachedLedgerAggregation = CostDiagnosticsLedgerAggregationResolver.make(
+            cwlEnabled: self.cwlEnabled,
+            cwlWindowDays: self.cwlWindowDays,
+            modelContext: self.modelContext,
+            activeDeviceIDs: self.activeDeviceIDsForLedger)
+        self.cachedLedgerSignature = signature
     }
 
     private func sourceText(_ source: CostDiagnosticsDataSource) -> String {

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -1314,10 +1314,12 @@ struct CostDashboardInsights {
     /// series, model / service mix) come from the ledger — re-aggregated over
     /// the user's chosen window, which can exceed Mac's historyDays. Provider
     /// metadata (name, color, budget, loginMethod) still comes from the live
-    /// snapshot since the ledger stores only IDs + numbers. Providers in the
-    /// snapshot but absent from the ledger get no row (no cost yet); ledger
-    /// rollups with no matching live provider are dropped (stale / removed
-    /// provider — no metadata to render).
+    /// snapshot since the ledger stores only IDs + numbers. Fresh snapshot
+    /// providers absent from the ledger can fill a missing row, and their
+    /// daily/model/service points are folded into the same aggregate so every
+    /// Cost surface reads one consistent result. Ledger rollups with no
+    /// matching live provider are dropped (stale / removed provider — no
+    /// metadata to render).
     static func fromLedger(
         aggregation: CostLedgerAggregation,
         snapshot: SyncedUsageSnapshot,
@@ -1328,6 +1330,21 @@ struct CostDashboardInsights {
 
         var providerRows: [ProviderRow] = []
         var representedProviderKeys = Set<String>()
+        var dailyTotals = Dictionary(
+            uniqueKeysWithValues: aggregation.dailyPoints.map { point in
+                (point.dayKey, (costUSD: point.costUSD, totalTokens: point.totalTokens))
+            })
+        var modelTotals = Dictionary(
+            uniqueKeysWithValues: aggregation.modelMix.map { ($0.label, $0.costUSD) })
+        var modelSplits = Dictionary(
+            uniqueKeysWithValues: aggregation.modelMix.compactMap {
+                bd -> (String, (std: Double, fast: Double))? in
+                guard bd.standardCostUSD != nil || bd.priorityCostUSD != nil else { return nil }
+                return (bd.label, (bd.standardCostUSD ?? 0, bd.priorityCostUSD ?? 0))
+            })
+        var serviceTotals = Dictionary(
+            uniqueKeysWithValues: aggregation.serviceMix.map { ($0.label, $0.costUSD) })
+
         for rollup in aggregation.providerRollups.values {
             // Match on the actual (providerID, accountEmail) tuple — avoids the
             // "_"-vs-"" nil-sentinel mismatch between the ledger composite key
@@ -1355,6 +1372,9 @@ struct CostDashboardInsights {
             representedProviderKeys.insert(provider.cardIdentityKey)
         }
 
+        let fallbackCutoffKey = CostLedgerService.cutoffDayKey(
+            windowDays: aggregation.windowDays,
+            asOf: Date())
         for provider in liveProviders where !representedProviderKeys.contains(provider.cardIdentityKey) {
             if let snapshotFallbackCutoff, provider.lastUpdated <= snapshotFallbackCutoff {
                 continue
@@ -1375,7 +1395,8 @@ struct CostDashboardInsights {
             let todayTotals = costSummary.todayTotals()
             let todayCost = todayTotals.costUSD ?? 0
             let todayTokens = todayTotals.tokens ?? 0
-            let providerDailyPoints = costSummary.daily.compactMap(Self.dailyPoint)
+            let fallbackSyncPoints = costSummary.daily.filter { $0.dayKey >= fallbackCutoffKey }
+            let providerDailyPoints = fallbackSyncPoints.compactMap(Self.dailyPoint)
             guard totals.costUSD > 0 || todayCost > 0 || totals.tokens > 0 || todayTokens > 0 else {
                 continue
             }
@@ -1386,6 +1407,23 @@ struct CostDashboardInsights {
                 thirtyDayTokens: totals.tokens,
                 todayTokens: todayTokens,
                 dailyPoints: providerDailyPoints))
+
+            for point in fallbackSyncPoints {
+                dailyTotals[point.dayKey, default: (0, 0)].costUSD += point.costUSD
+                dailyTotals[point.dayKey, default: (0, 0)].totalTokens += point.totalTokens
+
+                for breakdown in point.modelBreakdowns where breakdown.costUSD > 0 {
+                    modelTotals[breakdown.label, default: 0] += breakdown.costUSD
+                    if breakdown.standardCostUSD != nil || breakdown.priorityCostUSD != nil {
+                        modelSplits[breakdown.label, default: (0, 0)].std += breakdown.standardCostUSD ?? 0
+                        modelSplits[breakdown.label, default: (0, 0)].fast += breakdown.priorityCostUSD ?? 0
+                    }
+                }
+
+                for breakdown in point.serviceBreakdowns where breakdown.costUSD > 0 {
+                    serviceTotals[breakdown.label, default: 0] += breakdown.costUSD
+                }
+            }
         }
 
         var budgetRows: [CostBudgetRow] = []
@@ -1395,18 +1433,15 @@ struct CostDashboardInsights {
             }
         }
 
-        let dailyPoints = aggregation.dailyPoints.compactMap(Self.dailyPoint)
-
-        let modelTotals = Dictionary(
-            uniqueKeysWithValues: aggregation.modelMix.map { ($0.label, $0.costUSD) })
-        let modelSplits = Dictionary(
-            uniqueKeysWithValues: aggregation.modelMix.compactMap {
-                bd -> (String, (std: Double, fast: Double))? in
-                guard bd.standardCostUSD != nil || bd.priorityCostUSD != nil else { return nil }
-                return (bd.label, (bd.standardCostUSD ?? 0, bd.priorityCostUSD ?? 0))
-            })
-        let serviceTotals = Dictionary(
-            uniqueKeysWithValues: aggregation.serviceMix.map { ($0.label, $0.costUSD) })
+        let dailyPoints: [DailyPoint] = dailyTotals.keys.compactMap { dayKey in
+            guard let date = Self.dayKeyFormatter.date(from: dayKey),
+                  let totals = dailyTotals[dayKey] else { return nil }
+            return DailyPoint(
+                dayKey: dayKey,
+                date: date,
+                costUSD: totals.costUSD,
+                totalTokens: totals.totalTokens)
+        }
 
         return CostDashboardInsights(
             providerRows: providerRows.sorted { lhs, rhs in

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -3901,12 +3901,14 @@ private struct CostSettingsView: View {
         .onChange(of: self.cwlEnabled) { _, isOn in
             // First enable: import the existing blob history into the ledger so
             // the dashboard has data immediately instead of waiting for the next
-            // Mac sync. On failure, revert the toggle (CWL stays off, blob path
-            // keeps working). Idempotent — re-enabling is a cheap no-op.
+            // Mac sync. If the user previously cleared local history, keep that
+            // clear boundary so re-enabling does not restore older blob data. On
+            // failure, revert the toggle (CWL stays off, blob path keeps working).
+            // Idempotent — re-enabling is a cheap no-op.
             guard isOn else { return }
             do {
-                try CostLedgerService.seedFromExistingBlobs(in: self.modelContext)
-                UserDefaults.standard.removeObject(forKey: MobileSettingsKeys.cwlBlobSeedClearedAt)
+                try CostLedgerService.seedFromExistingBlobsRespectingClearTombstone(
+                    in: self.modelContext)
             } catch {
                 self.cwlEnabled = false
             }

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -465,6 +465,7 @@ private struct CostTab: View {
     @Environment(\.modelContext) private var modelContext
     @AppStorage(MobileSettingsKeys.cwlEnabled) private var cwlEnabled = MobileSettingsDefaults.cwlEnabled
     @AppStorage(MobileSettingsKeys.cwlWindowDays) private var cwlWindowDays = MobileSettingsDefaults.cwlWindowDays
+    @AppStorage(MobileSettingsKeys.cwlBlobSeedClearedAt) private var cwlBlobSeedClearedAt: Double = 0
 
     private var displaySnapshot: SyncedUsageSnapshot? {
         if self.isDemoMode {
@@ -517,6 +518,7 @@ private struct CostTab: View {
             "\(latestSync)",
             "\(latestProviderUpdate)",
             "\(providerCount)",
+            "\(self.cwlBlobSeedClearedAt)",
         ].joined(separator: "|")
     }
 

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -400,7 +400,8 @@ enum CostTabInsightsResolver {
             if aggregation.hasDisplayData {
                 insights = CostDashboardInsights.fromLedger(
                     aggregation: aggregation,
-                    snapshot: snapshot)
+                    snapshot: snapshot,
+                    includeSnapshotFallbackForMissingProviders: !clearedLocalHistory)
             } else if clearedLocalHistory {
                 insights = CostDashboardInsights(
                     providerRows: [],
@@ -1209,7 +1210,8 @@ struct CostDashboardInsights {
     /// provider — no metadata to render).
     static func fromLedger(
         aggregation: CostLedgerAggregation,
-        snapshot: SyncedUsageSnapshot) -> CostDashboardInsights
+        snapshot: SyncedUsageSnapshot,
+        includeSnapshotFallbackForMissingProviders: Bool = true) -> CostDashboardInsights
     {
         let todayKey = Self.dayKeyFormatter.string(from: Date())
         let liveProviders = MockProviderDetector.filteredProviders(from: snapshot)
@@ -1243,34 +1245,36 @@ struct CostDashboardInsights {
             representedProviderKeys.insert(provider.cardIdentityKey)
         }
 
-        for provider in liveProviders where !representedProviderKeys.contains(provider.cardIdentityKey) {
-            guard let costSummary = provider.costSummary else { continue }
-            let emptyRollup = CostLedgerProviderRollup(
-                providerID: provider.providerID,
-                accountEmail: provider.accountEmail,
-                totalCostUSD: 0,
-                totalTokens: 0,
-                dailyPoints: [],
-                modelBreakdowns: [],
-                serviceBreakdowns: [])
-            let totals = Self.ledgerDisplayTotals(
-                rollup: emptyRollup,
-                provider: provider,
-                windowDays: aggregation.windowDays)
-            let todayTotals = costSummary.todayTotals()
-            let todayCost = todayTotals.costUSD ?? 0
-            let todayTokens = todayTotals.tokens ?? 0
-            let providerDailyPoints = costSummary.daily.compactMap(Self.dailyPoint)
-            guard totals.costUSD > 0 || todayCost > 0 || totals.tokens > 0 || todayTokens > 0 else {
-                continue
+        if includeSnapshotFallbackForMissingProviders {
+            for provider in liveProviders where !representedProviderKeys.contains(provider.cardIdentityKey) {
+                guard let costSummary = provider.costSummary else { continue }
+                let emptyRollup = CostLedgerProviderRollup(
+                    providerID: provider.providerID,
+                    accountEmail: provider.accountEmail,
+                    totalCostUSD: 0,
+                    totalTokens: 0,
+                    dailyPoints: [],
+                    modelBreakdowns: [],
+                    serviceBreakdowns: [])
+                let totals = Self.ledgerDisplayTotals(
+                    rollup: emptyRollup,
+                    provider: provider,
+                    windowDays: aggregation.windowDays)
+                let todayTotals = costSummary.todayTotals()
+                let todayCost = todayTotals.costUSD ?? 0
+                let todayTokens = todayTotals.tokens ?? 0
+                let providerDailyPoints = costSummary.daily.compactMap(Self.dailyPoint)
+                guard totals.costUSD > 0 || todayCost > 0 || totals.tokens > 0 || todayTokens > 0 else {
+                    continue
+                }
+                providerRows.append(ProviderRow(
+                    provider: provider,
+                    thirtyDayCost: totals.costUSD,
+                    todayCost: todayCost,
+                    thirtyDayTokens: totals.tokens,
+                    todayTokens: todayTokens,
+                    dailyPoints: providerDailyPoints))
             }
-            providerRows.append(ProviderRow(
-                provider: provider,
-                thirtyDayCost: totals.costUSD,
-                todayCost: todayCost,
-                thirtyDayTokens: totals.tokens,
-                todayTokens: todayTokens,
-                dailyPoints: providerDailyPoints))
         }
 
         var budgetRows: [CostBudgetRow] = []
@@ -2871,7 +2875,10 @@ private struct CostDiagnosticsView: View {
                 activeDeviceIDs: self.activeDeviceIDsForLedger)
             : nil
         let insights = aggregation.map {
-            CostDashboardInsights.fromLedger(aggregation: $0, snapshot: snapshot)
+            CostDashboardInsights.fromLedger(
+                aggregation: $0,
+                snapshot: snapshot,
+                includeSnapshotFallbackForMissingProviders: !CostLedgerService.hasBlobSeedClearTombstone())
         } ?? CostDashboardInsights(snapshot: snapshot)
 
         return CostDiagnosticsReport.make(

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -387,6 +387,53 @@ enum CostLedgerDeviceFilter {
     }
 }
 
+enum CostLedgerRefreshClock {
+    static func currentDayKey(now: Date = Date()) -> String {
+        SyncCostSummary.iso8601DayKey(for: now)
+    }
+
+    static func nanosecondsUntilNextLocalDay(now: Date = Date()) -> UInt64 {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .current
+        let startOfDay = calendar.startOfDay(for: now)
+        let nextDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) ?? now.addingTimeInterval(60)
+        let seconds = max(1, nextDay.timeIntervalSince(now) + 1)
+        return UInt64(seconds * 1_000_000_000)
+    }
+}
+
+enum CostLedgerRefreshSignature {
+    static func make(
+        isEnabled: Bool,
+        windowDays: Int,
+        activeDeviceIDs: Set<String>?,
+        snapshots: [SyncedUsageSnapshot],
+        clearTombstone: Double,
+        currentDayKey: String) -> String
+    {
+        guard isEnabled else {
+            return "off"
+        }
+        let activeDeviceIDs = activeDeviceIDs?.sorted().joined(separator: ",") ?? "_"
+        let latestSync = snapshots
+            .map(\.syncTimestamp.timeIntervalSince1970)
+            .max() ?? 0
+        let latestProviderUpdate = snapshots
+            .flatMap { $0.providers.map(\.lastUpdated.timeIntervalSince1970) }
+            .max() ?? 0
+        let providerCount = snapshots.reduce(0) { $0 + $1.providers.count }
+        return [
+            currentDayKey,
+            "\(windowDays)",
+            activeDeviceIDs,
+            "\(latestSync)",
+            "\(latestProviderUpdate)",
+            "\(providerCount)",
+            "\(clearTombstone)",
+        ].joined(separator: "|")
+    }
+}
+
 enum CostTabInsightsResolver {
     static func make(
         snapshot: SyncedUsageSnapshot,
@@ -504,6 +551,7 @@ private struct CostTab: View {
     @AppStorage(MobileSettingsKeys.cwlEnabled) private var cwlEnabled = MobileSettingsDefaults.cwlEnabled
     @AppStorage(MobileSettingsKeys.cwlWindowDays) private var cwlWindowDays = MobileSettingsDefaults.cwlWindowDays
     @AppStorage(MobileSettingsKeys.cwlBlobSeedClearedAt) private var cwlBlobSeedClearedAt: Double = 0
+    @State private var ledgerRefreshDayKey = CostLedgerRefreshClock.currentDayKey()
 
     private var displaySnapshot: SyncedUsageSnapshot? {
         if self.isDemoMode {
@@ -540,25 +588,13 @@ private struct CostTab: View {
     }
 
     private var ledgerRefreshSignature: String {
-        guard self.shouldUseLedger else {
-            return "off"
-        }
-        let activeDeviceIDs = self.activeDeviceIDsForLedger?.sorted().joined(separator: ",") ?? "_"
-        let latestSync = self.usageData.deviceSnapshots
-            .map(\.syncTimestamp.timeIntervalSince1970)
-            .max() ?? 0
-        let latestProviderUpdate = self.usageData.deviceSnapshots
-            .flatMap { $0.providers.map(\.lastUpdated.timeIntervalSince1970) }
-            .max() ?? 0
-        let providerCount = self.usageData.deviceSnapshots.reduce(0) { $0 + $1.providers.count }
-        return [
-            "\(self.cwlWindowDays)",
-            activeDeviceIDs,
-            "\(latestSync)",
-            "\(latestProviderUpdate)",
-            "\(providerCount)",
-            "\(self.cwlBlobSeedClearedAt)",
-        ].joined(separator: "|")
+        CostLedgerRefreshSignature.make(
+            isEnabled: self.shouldUseLedger,
+            windowDays: self.cwlWindowDays,
+            activeDeviceIDs: self.activeDeviceIDsForLedger,
+            snapshots: self.usageData.deviceSnapshots,
+            clearTombstone: self.cwlBlobSeedClearedAt,
+            currentDayKey: self.ledgerRefreshDayKey)
     }
 
     @MainActor
@@ -625,6 +661,20 @@ private struct CostTab: View {
             .task(id: self.ledgerRefreshSignature) {
                 self.refreshLedgerAggregation(for: self.ledgerRefreshSignature)
             }
+            .task {
+                await self.keepLedgerRefreshDayCurrent()
+            }
+        }
+    }
+
+    @MainActor
+    private func keepLedgerRefreshDayCurrent() async {
+        while !Task.isCancelled {
+            let currentDayKey = CostLedgerRefreshClock.currentDayKey()
+            if self.ledgerRefreshDayKey != currentDayKey {
+                self.ledgerRefreshDayKey = currentDayKey
+            }
+            try? await Task.sleep(nanoseconds: CostLedgerRefreshClock.nanosecondsUntilNextLocalDay())
         }
     }
 }
@@ -2941,6 +2991,7 @@ private struct CostDiagnosticsView: View {
     @AppStorage(MobileSettingsKeys.cwlBlobSeedClearedAt) private var cwlBlobSeedClearedAt: Double = 0
     @State private var cachedLedgerSignature: String?
     @State private var cachedLedgerAggregation: CostLedgerAggregation?
+    @State private var ledgerRefreshDayKey = CostLedgerRefreshClock.currentDayKey()
 
     var body: some View {
         List {
@@ -3016,6 +3067,9 @@ private struct CostDiagnosticsView: View {
         .task(id: self.ledgerRefreshSignature) {
             self.refreshLedgerAggregation(for: self.ledgerRefreshSignature)
         }
+        .task {
+            await self.keepLedgerRefreshDayCurrent()
+        }
     }
 
     private var report: CostDiagnosticsReport? {
@@ -3039,25 +3093,13 @@ private struct CostDiagnosticsView: View {
     }
 
     private var ledgerRefreshSignature: String {
-        guard self.cwlEnabled else {
-            return "off"
-        }
-        let activeDeviceIDs = self.activeDeviceIDsForLedger?.sorted().joined(separator: ",") ?? "_"
-        let latestSync = self.usageData.deviceSnapshots
-            .map(\.syncTimestamp.timeIntervalSince1970)
-            .max() ?? 0
-        let latestProviderUpdate = self.usageData.deviceSnapshots
-            .flatMap { $0.providers.map(\.lastUpdated.timeIntervalSince1970) }
-            .max() ?? 0
-        let providerCount = self.usageData.deviceSnapshots.reduce(0) { $0 + $1.providers.count }
-        return [
-            "\(self.cwlWindowDays)",
-            activeDeviceIDs,
-            "\(latestSync)",
-            "\(latestProviderUpdate)",
-            "\(providerCount)",
-            "\(self.cwlBlobSeedClearedAt)",
-        ].joined(separator: "|")
+        CostLedgerRefreshSignature.make(
+            isEnabled: self.cwlEnabled,
+            windowDays: self.cwlWindowDays,
+            activeDeviceIDs: self.activeDeviceIDsForLedger,
+            snapshots: self.usageData.deviceSnapshots,
+            clearTombstone: self.cwlBlobSeedClearedAt,
+            currentDayKey: self.ledgerRefreshDayKey)
     }
 
     @MainActor
@@ -3073,6 +3115,17 @@ private struct CostDiagnosticsView: View {
             modelContext: self.modelContext,
             activeDeviceIDs: self.activeDeviceIDsForLedger)
         self.cachedLedgerSignature = signature
+    }
+
+    @MainActor
+    private func keepLedgerRefreshDayCurrent() async {
+        while !Task.isCancelled {
+            let currentDayKey = CostLedgerRefreshClock.currentDayKey()
+            if self.ledgerRefreshDayKey != currentDayKey {
+                self.ledgerRefreshDayKey = currentDayKey
+            }
+            try? await Task.sleep(nanoseconds: CostLedgerRefreshClock.nanosecondsUntilNextLocalDay())
+        }
     }
 
     private func sourceText(_ source: CostDiagnosticsDataSource) -> String {

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -393,7 +393,7 @@ enum CostTabInsightsResolver {
         ledgerAggregation: CostLedgerAggregation?,
         isLedgerEnabled: Bool,
         isDemoMode: Bool,
-        clearedLocalHistory: Bool) -> CostDashboardInsights?
+        localHistoryClearedAt: Date?) -> CostDashboardInsights?
     {
         let insights: CostDashboardInsights
         if isLedgerEnabled, !isDemoMode, let aggregation = ledgerAggregation {
@@ -401,12 +401,12 @@ enum CostTabInsightsResolver {
                 insights = CostDashboardInsights.fromLedger(
                     aggregation: aggregation,
                     snapshot: snapshot,
-                    includeSnapshotFallbackForMissingProviders: !clearedLocalHistory)
-            } else if clearedLocalHistory {
+                    snapshotFallbackCutoff: localHistoryClearedAt)
+            } else if localHistoryClearedAt != nil {
                 insights = CostDashboardInsights.fromLedger(
                     aggregation: aggregation,
                     snapshot: snapshot,
-                    includeSnapshotFallbackForMissingProviders: false)
+                    snapshotFallbackCutoff: localHistoryClearedAt)
             } else {
                 insights = CostDashboardInsights(snapshot: snapshot)
             }
@@ -458,7 +458,7 @@ private struct CostTab: View {
             ledgerAggregation: aggregation,
             isLedgerEnabled: self.cwlEnabled,
             isDemoMode: self.isDemoMode,
-            clearedLocalHistory: CostLedgerService.hasBlobSeedClearTombstone())
+            localHistoryClearedAt: CostLedgerService.blobSeedClearTombstoneDate())
     }
 
     private var activeDeviceIDsForLedger: Set<String>? {
@@ -1208,7 +1208,7 @@ struct CostDashboardInsights {
     static func fromLedger(
         aggregation: CostLedgerAggregation,
         snapshot: SyncedUsageSnapshot,
-        includeSnapshotFallbackForMissingProviders: Bool = true) -> CostDashboardInsights
+        snapshotFallbackCutoff: Date? = nil) -> CostDashboardInsights
     {
         let todayKey = Self.dayKeyFormatter.string(from: Date())
         let liveProviders = MockProviderDetector.filteredProviders(from: snapshot)
@@ -1242,36 +1242,37 @@ struct CostDashboardInsights {
             representedProviderKeys.insert(provider.cardIdentityKey)
         }
 
-        if includeSnapshotFallbackForMissingProviders {
-            for provider in liveProviders where !representedProviderKeys.contains(provider.cardIdentityKey) {
-                guard let costSummary = provider.costSummary else { continue }
-                let emptyRollup = CostLedgerProviderRollup(
-                    providerID: provider.providerID,
-                    accountEmail: provider.accountEmail,
-                    totalCostUSD: 0,
-                    totalTokens: 0,
-                    dailyPoints: [],
-                    modelBreakdowns: [],
-                    serviceBreakdowns: [])
-                let totals = Self.ledgerDisplayTotals(
-                    rollup: emptyRollup,
-                    provider: provider,
-                    windowDays: aggregation.windowDays)
-                let todayTotals = costSummary.todayTotals()
-                let todayCost = todayTotals.costUSD ?? 0
-                let todayTokens = todayTotals.tokens ?? 0
-                let providerDailyPoints = costSummary.daily.compactMap(Self.dailyPoint)
-                guard totals.costUSD > 0 || todayCost > 0 || totals.tokens > 0 || todayTokens > 0 else {
-                    continue
-                }
-                providerRows.append(ProviderRow(
-                    provider: provider,
-                    thirtyDayCost: totals.costUSD,
-                    todayCost: todayCost,
-                    thirtyDayTokens: totals.tokens,
-                    todayTokens: todayTokens,
-                    dailyPoints: providerDailyPoints))
+        for provider in liveProviders where !representedProviderKeys.contains(provider.cardIdentityKey) {
+            if let snapshotFallbackCutoff, provider.lastUpdated <= snapshotFallbackCutoff {
+                continue
             }
+            guard let costSummary = provider.costSummary else { continue }
+            let emptyRollup = CostLedgerProviderRollup(
+                providerID: provider.providerID,
+                accountEmail: provider.accountEmail,
+                totalCostUSD: 0,
+                totalTokens: 0,
+                dailyPoints: [],
+                modelBreakdowns: [],
+                serviceBreakdowns: [])
+            let totals = Self.ledgerDisplayTotals(
+                rollup: emptyRollup,
+                provider: provider,
+                windowDays: aggregation.windowDays)
+            let todayTotals = costSummary.todayTotals()
+            let todayCost = todayTotals.costUSD ?? 0
+            let todayTokens = todayTotals.tokens ?? 0
+            let providerDailyPoints = costSummary.daily.compactMap(Self.dailyPoint)
+            guard totals.costUSD > 0 || todayCost > 0 || totals.tokens > 0 || todayTokens > 0 else {
+                continue
+            }
+            providerRows.append(ProviderRow(
+                provider: provider,
+                thirtyDayCost: totals.costUSD,
+                todayCost: todayCost,
+                thirtyDayTokens: totals.tokens,
+                todayTokens: todayTokens,
+                dailyPoints: providerDailyPoints))
         }
 
         var budgetRows: [CostBudgetRow] = []
@@ -2875,7 +2876,7 @@ private struct CostDiagnosticsView: View {
             CostDashboardInsights.fromLedger(
                 aggregation: $0,
                 snapshot: snapshot,
-                includeSnapshotFallbackForMissingProviders: !CostLedgerService.hasBlobSeedClearTombstone())
+                snapshotFallbackCutoff: CostLedgerService.blobSeedClearTombstoneDate())
         } ?? CostDashboardInsights(snapshot: snapshot)
 
         return CostDiagnosticsReport.make(

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -403,13 +403,10 @@ enum CostTabInsightsResolver {
                     snapshot: snapshot,
                     includeSnapshotFallbackForMissingProviders: !clearedLocalHistory)
             } else if clearedLocalHistory {
-                insights = CostDashboardInsights(
-                    providerRows: [],
-                    dailyPoints: [],
-                    modelRows: [],
-                    serviceRows: [],
-                    budgetRows: [],
-                    cwlWindowDays: aggregation.windowDays)
+                insights = CostDashboardInsights.fromLedger(
+                    aggregation: aggregation,
+                    snapshot: snapshot,
+                    includeSnapshotFallbackForMissingProviders: false)
             } else {
                 insights = CostDashboardInsights(snapshot: snapshot)
             }

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -387,6 +387,38 @@ enum CostLedgerDeviceFilter {
     }
 }
 
+enum CostTabInsightsResolver {
+    static func make(
+        snapshot: SyncedUsageSnapshot,
+        ledgerAggregation: CostLedgerAggregation?,
+        isLedgerEnabled: Bool,
+        isDemoMode: Bool,
+        clearedLocalHistory: Bool) -> CostDashboardInsights?
+    {
+        let insights: CostDashboardInsights
+        if isLedgerEnabled, !isDemoMode, let aggregation = ledgerAggregation {
+            if aggregation.hasDisplayData {
+                insights = CostDashboardInsights.fromLedger(
+                    aggregation: aggregation,
+                    snapshot: snapshot)
+            } else if clearedLocalHistory {
+                insights = CostDashboardInsights(
+                    providerRows: [],
+                    dailyPoints: [],
+                    modelRows: [],
+                    serviceRows: [],
+                    budgetRows: [],
+                    cwlWindowDays: aggregation.windowDays)
+            } else {
+                insights = CostDashboardInsights(snapshot: snapshot)
+            }
+        } else {
+            insights = CostDashboardInsights(snapshot: snapshot)
+        }
+        return insights.hasDisplayData ? insights : nil
+    }
+}
+
 private struct CostTab: View {
     let usageData: SyncedUsageData
     @Binding var isDemoMode: Bool
@@ -413,22 +445,22 @@ private struct CostTab: View {
     /// Synchronous compute ensures first render has data for UI tests and user-perceived responsiveness.
     private var currentInsights: CostDashboardInsights? {
         guard let snapshot = self.displaySnapshot else { return nil }
-        let insights: CostDashboardInsights
         // CWL path only outside demo mode (demo uses a synthetic snapshot with
-        // no ledger). `try?` falls back to the blob path on any ledger error.
-        if self.cwlEnabled,
-           !self.isDemoMode,
-           let aggregation = try? CostLedgerService.aggregateSeedingFromExistingBlobsIfNeeded(
+        // no ledger). A missing aggregation falls back to the blob path, while
+        // an intentionally empty ledger after Clear Local Cost History stays
+        // empty instead of rebuilding stale costs from synced blobs.
+        let aggregation = self.cwlEnabled && !self.isDemoMode
+            ? try? CostLedgerService.aggregateSeedingFromExistingBlobsIfNeeded(
                windowDays: self.cwlWindowDays,
                in: self.modelContext,
                activeDeviceIDs: self.activeDeviceIDsForLedger)
-        {
-            insights = CostDashboardInsights.fromLedger(
-                aggregation: aggregation, snapshot: snapshot)
-        } else {
-            insights = CostDashboardInsights(snapshot: snapshot)
-        }
-        return insights.hasDisplayData ? insights : nil
+            : nil
+        return CostTabInsightsResolver.make(
+            snapshot: snapshot,
+            ledgerAggregation: aggregation,
+            isLedgerEnabled: self.cwlEnabled,
+            isDemoMode: self.isDemoMode,
+            clearedLocalHistory: CostLedgerService.hasBlobSeedClearTombstone())
     }
 
     private var activeDeviceIDsForLedger: Set<String>? {

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -1473,14 +1473,18 @@ struct CostDashboardInsights {
             let todayTokens = todayTotals.tokens ?? 0
             let fallbackSyncPoints = costSummary.daily.filter { $0.dayKey >= fallbackCutoffKey }
             let providerDailyPoints = fallbackSyncPoints.compactMap(Self.dailyPoint)
-            guard totals.costUSD > 0 || todayCost > 0 || totals.tokens > 0 || todayTokens > 0 else {
+            let fallbackDailyCost = fallbackSyncPoints.reduce(0) { $0 + $1.costUSD }
+            let fallbackDailyTokens = fallbackSyncPoints.reduce(0) { $0 + $1.totalTokens }
+            let resolvedCost = max(totals.costUSD, max(fallbackDailyCost, todayCost))
+            let resolvedTokens = max(totals.tokens, max(fallbackDailyTokens, todayTokens))
+            guard resolvedCost > 0 || resolvedTokens > 0 else {
                 continue
             }
             providerRows.append(ProviderRow(
                 provider: provider,
-                thirtyDayCost: totals.costUSD,
+                thirtyDayCost: resolvedCost,
                 todayCost: todayCost,
-                thirtyDayTokens: totals.tokens,
+                thirtyDayTokens: resolvedTokens,
                 todayTokens: todayTokens,
                 dailyPoints: providerDailyPoints))
 

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -417,6 +417,41 @@ enum CostTabInsightsResolver {
     }
 }
 
+enum CostDiagnosticsReportResolver {
+    static func make(
+        snapshot: SyncedUsageSnapshot,
+        ledgerAggregation: CostLedgerAggregation?,
+        rawDeviceSnapshots: [SyncedUsageSnapshot],
+        activeDeviceSnapshots: [SyncedUsageSnapshot],
+        cwlEnabled: Bool,
+        cwlWindowDays: Int,
+        localHistoryClearedAt: Date?) -> CostDiagnosticsReport?
+    {
+        guard let insights = CostTabInsightsResolver.make(
+            snapshot: snapshot,
+            ledgerAggregation: ledgerAggregation,
+            isLedgerEnabled: cwlEnabled,
+            isDemoMode: false,
+            localHistoryClearedAt: localHistoryClearedAt)
+        else {
+            return nil
+        }
+
+        let reportsLocalLedger = cwlEnabled && (
+            ledgerAggregation?.hasDisplayData == true || localHistoryClearedAt != nil
+        )
+
+        return CostDiagnosticsReport.make(
+            insights: insights,
+            snapshot: snapshot,
+            rawDeviceSnapshots: rawDeviceSnapshots,
+            activeDeviceSnapshots: activeDeviceSnapshots,
+            cwlEnabled: cwlEnabled,
+            cwlWindowDays: cwlWindowDays,
+            ledgerAvailable: reportsLocalLedger)
+    }
+}
+
 private struct CostTab: View {
     let usageData: SyncedUsageData
     @Binding var isDemoMode: Bool
@@ -2872,21 +2907,15 @@ private struct CostDiagnosticsView: View {
                 in: self.modelContext,
                 activeDeviceIDs: self.activeDeviceIDsForLedger)
             : nil
-        let insights = aggregation.map {
-            CostDashboardInsights.fromLedger(
-                aggregation: $0,
-                snapshot: snapshot,
-                snapshotFallbackCutoff: CostLedgerService.blobSeedClearTombstoneDate())
-        } ?? CostDashboardInsights(snapshot: snapshot)
 
-        return CostDiagnosticsReport.make(
-            insights: insights,
+        return CostDiagnosticsReportResolver.make(
             snapshot: snapshot,
+            ledgerAggregation: aggregation,
             rawDeviceSnapshots: self.usageData.rawDeviceSnapshots,
             activeDeviceSnapshots: self.usageData.deviceSnapshots,
             cwlEnabled: self.cwlEnabled,
             cwlWindowDays: self.cwlWindowDays,
-            ledgerAvailable: aggregation != nil)
+            localHistoryClearedAt: CostLedgerService.blobSeedClearTombstoneDate())
     }
 
     private var activeDeviceIDsForLedger: Set<String>? {

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -422,6 +422,14 @@ enum CostLedgerRefreshSignature {
             .flatMap { $0.providers.map(\.lastUpdated.timeIntervalSince1970) }
             .max() ?? 0
         let providerCount = snapshots.reduce(0) { $0 + $1.providers.count }
+        let providerIdentities = snapshots
+            .flatMap { snapshot in
+                snapshot.providers.map { provider in
+                    "\(snapshot.deviceID ?? "_"):\(provider.cardIdentityKey)"
+                }
+            }
+            .sorted()
+            .joined(separator: ";")
         return [
             currentDayKey,
             "\(windowDays)",
@@ -429,6 +437,7 @@ enum CostLedgerRefreshSignature {
             "\(latestSync)",
             "\(latestProviderUpdate)",
             "\(providerCount)",
+            providerIdentities,
             "\(clearTombstone)",
         ].joined(separator: "|")
     }

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -2740,7 +2740,7 @@ private struct DeveloperToolsView: View {
                         summary: "Alert push subscription state")
                 }
             } footer: {
-                Text("These tools expose internal sync and notification state to help diagnose issues. No sensitive data is shown.")
+                Text("These tools may show internal sync state, device identifiers, and account emails for debugging.")
                     .font(.caption2)
             }
         }
@@ -3906,6 +3906,7 @@ private struct CostSettingsView: View {
             guard isOn else { return }
             do {
                 try CostLedgerService.seedFromExistingBlobs(in: self.modelContext)
+                UserDefaults.standard.removeObject(forKey: MobileSettingsKeys.cwlBlobSeedClearedAt)
             } catch {
                 self.cwlEnabled = false
             }

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -475,6 +475,21 @@ enum CostDiagnosticsReportResolver {
     }
 }
 
+enum CostDiagnosticsLedgerAggregationResolver {
+    static func make(
+        cwlEnabled: Bool,
+        cwlWindowDays: Int,
+        modelContext: ModelContext,
+        activeDeviceIDs: Set<String>?) -> CostLedgerAggregation?
+    {
+        guard cwlEnabled else { return nil }
+        return try? CostLedgerService.aggregateSeedingFromExistingBlobsIfNeeded(
+            windowDays: cwlWindowDays,
+            in: modelContext,
+            activeDeviceIDs: activeDeviceIDs)
+    }
+}
+
 private struct CostTab: View {
     let usageData: SyncedUsageData
     @Binding var isDemoMode: Bool
@@ -2964,12 +2979,11 @@ private struct CostDiagnosticsView: View {
 
     private var report: CostDiagnosticsReport? {
         guard let snapshot = self.usageData.snapshot else { return nil }
-        let aggregation = self.cwlEnabled
-            ? try? CostLedgerService.aggregate(
-                windowDays: self.cwlWindowDays,
-                in: self.modelContext,
-                activeDeviceIDs: self.activeDeviceIDsForLedger)
-            : nil
+        let aggregation = CostDiagnosticsLedgerAggregationResolver.make(
+            cwlEnabled: self.cwlEnabled,
+            cwlWindowDays: self.cwlWindowDays,
+            modelContext: self.modelContext,
+            activeDeviceIDs: self.activeDeviceIDsForLedger)
 
         return CostDiagnosticsReportResolver.make(
             snapshot: snapshot,

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -394,11 +394,10 @@ private struct CostTab: View {
 
     // Round 6 / P4b — Cost Window Ledger dispatch. When `cwlEnabled` and not
     // in demo mode, the dashboard reads the ledger (re-windowed by
-    // `cwlWindowDays`) instead of the blob path. Both default to the historical
-    // behavior (OFF / 30d) so untouched users are unaffected.
+    // `cwlWindowDays`) instead of the blob path.
     @Environment(\.modelContext) private var modelContext
-    @AppStorage(MobileSettingsKeys.cwlEnabled) private var cwlEnabled = false
-    @AppStorage(MobileSettingsKeys.cwlWindowDays) private var cwlWindowDays = 30
+    @AppStorage(MobileSettingsKeys.cwlEnabled) private var cwlEnabled = MobileSettingsDefaults.cwlEnabled
+    @AppStorage(MobileSettingsKeys.cwlWindowDays) private var cwlWindowDays = MobileSettingsDefaults.cwlWindowDays
 
     private var displaySnapshot: SyncedUsageSnapshot? {
         if self.isDemoMode {
@@ -2724,6 +2723,15 @@ private struct DeveloperToolsView: View {
                 }
 
                 NavigationLink {
+                    CostDiagnosticsView(usageData: self.usageData)
+                } label: {
+                    SettingSummaryRow(
+                        title: "Cost Diagnostics",
+                        symbolName: "dollarsign.gauge.chart.lefthalf.righthalf",
+                        summary: String(localized: "Audit Cost totals and merge rules"))
+                }
+
+                NavigationLink {
                     PushSetupDiagnosticView()
                 } label: {
                     SettingSummaryRow(
@@ -2732,11 +2740,209 @@ private struct DeveloperToolsView: View {
                         summary: "Alert push subscription state")
                 }
             } footer: {
-                Text("These tools expose internal sync and push state to help diagnose issues.")
+                Text("These tools expose internal sync and notification state to help diagnose issues. No sensitive data is shown.")
                     .font(.caption2)
             }
         }
         .navigationTitle("Developer Tools")
+    }
+}
+
+// MARK: - Cost Diagnostics View
+
+private struct CostDiagnosticsView: View {
+    let usageData: SyncedUsageData
+
+    @Environment(\.modelContext) private var modelContext
+    @AppStorage(MobileSettingsKeys.cwlEnabled) private var cwlEnabled = MobileSettingsDefaults.cwlEnabled
+    @AppStorage(MobileSettingsKeys.cwlWindowDays) private var cwlWindowDays = MobileSettingsDefaults.cwlWindowDays
+
+    var body: some View {
+        List {
+            if let report = self.report {
+                Section("Summary") {
+                    LabeledContent("Source", value: self.sourceText(report.dataSource))
+                    LabeledContent("Window", value: String(format: String(localized: "%d days"), report.windowDays))
+                    LabeledContent("Total Cost", value: CostFormatting.usd(report.totalCostUSD))
+                    LabeledContent("Today", value: CostFormatting.usd(report.todayCostUSD))
+                    LabeledContent("Active Days", value: "\(report.activeDayCount)")
+                    LabeledContent("Top Driver", value: self.topDriverText(report))
+                    LabeledContent("Active Devices", value: "\(report.activeDeviceCount)")
+                    if report.excludedDeviceCount > 0 {
+                        LabeledContent("Excluded Devices", value: "\(report.excludedDeviceCount)")
+                    }
+                }
+
+                Section("Provider Rules") {
+                    ForEach(report.providerRules) { rule in
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text(rule.providerName)
+                                    .fontWeight(.medium)
+                                Spacer()
+                                Text(self.mergeRuleText(rule.rule))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            if let account = rule.accountEmail, !account.isEmpty {
+                                Text(account)
+                                    .font(.caption2)
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                    }
+                }
+
+                Section("Reconciliation") {
+                    ForEach(report.checks) { item in
+                        HStack(alignment: .top, spacing: 10) {
+                            Image(systemName: self.statusSymbol(item.status))
+                                .foregroundStyle(self.statusColor(item.status))
+                                .frame(width: 18)
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(self.checkTitle(item.kind))
+                                    .fontWeight(.medium)
+                                Text(self.checkDetail(item.detail))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+
+                Section("Raw Inputs") {
+                    NavigationLink {
+                        RawSyncDataView(usageData: self.usageData)
+                    } label: {
+                        SettingSummaryRow(
+                            title: "Open Raw Sync Data",
+                            symbolName: "doc.text.magnifyingglass",
+                            summary: String(localized: "Inspect per-device synced rows used as source input"))
+                    }
+                }
+            } else {
+                Section {
+                    Text("No cost data available")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .navigationTitle("Cost Diagnostics")
+    }
+
+    private var report: CostDiagnosticsReport? {
+        guard let snapshot = self.usageData.snapshot else { return nil }
+        let aggregation = self.cwlEnabled
+            ? try? CostLedgerService.aggregate(
+                windowDays: self.cwlWindowDays,
+                in: self.modelContext,
+                activeDeviceIDs: self.activeDeviceIDsForLedger)
+            : nil
+        let insights = aggregation.map {
+            CostDashboardInsights.fromLedger(aggregation: $0, snapshot: snapshot)
+        } ?? CostDashboardInsights(snapshot: snapshot)
+
+        return CostDiagnosticsReport.make(
+            insights: insights,
+            snapshot: snapshot,
+            rawDeviceSnapshots: self.usageData.rawDeviceSnapshots,
+            activeDeviceSnapshots: self.usageData.deviceSnapshots,
+            cwlEnabled: self.cwlEnabled,
+            cwlWindowDays: self.cwlWindowDays,
+            ledgerAvailable: aggregation != nil)
+    }
+
+    private var activeDeviceIDsForLedger: Set<String>? {
+        CostLedgerDeviceFilter.activeDeviceIDs(for: self.usageData.deviceSnapshots)
+    }
+
+    private func sourceText(_ source: CostDiagnosticsDataSource) -> String {
+        switch source {
+        case .localLedger:
+            String(localized: "Local Ledger")
+        case .syncedSnapshots:
+            String(localized: "Synced Snapshots")
+        case .syncedSnapshotsAfterLedgerFailure:
+            String(localized: "Synced Snapshots (ledger unavailable)")
+        }
+    }
+
+    private func mergeRuleText(_ rule: CostDiagnosticsMergeRule) -> String {
+        switch rule {
+        case .sumActiveDevices:
+            String(localized: "sum active devices")
+        case .latestAccountDay:
+            String(localized: "latest account/day row")
+        }
+    }
+
+    private func checkTitle(_ kind: CostDiagnosticsCheckKind) -> String {
+        switch kind {
+        case .providerShare:
+            String(localized: "Provider Share")
+        case .dailySpend:
+            String(localized: "Daily Spend")
+        case .modelMix:
+            String(localized: "Model Mix")
+        case .serviceMix:
+            String(localized: "Codex Service Mix")
+        case .shareCard:
+            String(localized: "Share Card")
+        }
+    }
+
+    private func checkDetail(_ detail: CostDiagnosticsCheckDetail) -> String {
+        switch detail {
+        case .matchesOverviewTotal:
+            String(localized: "Matches Overview total")
+        case .difference(let delta):
+            String(
+                format: String(localized: "Difference %@"),
+                CostFormatting.usd(delta))
+        case .covers(let fraction):
+            String(
+                format: String(localized: "Covers %.0f%% of total"),
+                fraction * 100)
+        case .noCostTotal:
+            String(localized: "No cost total")
+        case .noBreakdownData:
+            String(localized: "No breakdown data")
+        case .usesExactProviderDailyPoints:
+            String(localized: "Uses exact provider daily points")
+        case .sevenDayProviderDifference(let delta):
+            String(
+                format: String(localized: "7-day provider difference %@"),
+                CostFormatting.usd(delta))
+        }
+    }
+
+    private func topDriverText(_ report: CostDiagnosticsReport) -> String {
+        guard let name = report.topDriverName, let cost = report.topDriverCostUSD else {
+            return String(localized: "None")
+        }
+        return "\(name) · \(CostFormatting.usd(cost))"
+    }
+
+    private func statusSymbol(_ status: CostDiagnosticsStatus) -> String {
+        switch status {
+        case .pass:
+            "checkmark.circle.fill"
+        case .warning:
+            "exclamationmark.triangle.fill"
+        case .unavailable:
+            "minus.circle.fill"
+        }
+    }
+
+    private func statusColor(_ status: CostDiagnosticsStatus) -> Color {
+        switch status {
+        case .pass:
+            .green
+        case .warning:
+            .orange
+        case .unavailable:
+            .secondary
+        }
     }
 }
 
@@ -2935,6 +3141,9 @@ private enum MobileReleaseNotesCatalog {
                         String(localized: "New providers — iPhone now recognizes Sakana AI, Qoder, CrossModel, and ClawRouter from Mac sync, with provider colors, quota alerts, mock data, and detail pages included."),
                         String(localized: "CrossModel details — CrossModel now shows balance, uncollected spend, and daily, weekly, and monthly usage on iPhone instead of an empty provider page."),
                         String(localized: "Cost data integrity — Overview, Provider Share, Daily Spend, Model Mix, Codex Service Mix, and share cards now use the same provider-aware cost reducer so local CLI spend is summed across active Macs without double-counting account-level providers."),
+                        String(localized: "Cost history defaults — Local cost history now starts on with a 90-day window, and Cost Settings explains how it differs from the synced Mac snapshot path."),
+                        String(localized: "Cost diagnostics — Developer Tools can now show the source path, provider rules, and reconciliation checks behind the Cost totals."),
+                        String(localized: "Widget polish — updated timestamps are centered across every widget size and mode."),
                         String(localized: "Provider fixes included — the companion app understands the latest Mac data for Sakana AI quotas, Qoder credits, ClawRouter budget usage, CrossModel wallet usage, and upstream menu/provider reliability fixes."),
                     ]),
                 .init(
@@ -3595,8 +3804,8 @@ private struct CostSettingsView: View {
 
     // Round 6 / P4b — Cost Window Ledger controls.
     @Environment(\.modelContext) private var modelContext
-    @AppStorage(MobileSettingsKeys.cwlEnabled) private var cwlEnabled = false
-    @AppStorage(MobileSettingsKeys.cwlWindowDays) private var cwlWindowDays = 30
+    @AppStorage(MobileSettingsKeys.cwlEnabled) private var cwlEnabled = MobileSettingsDefaults.cwlEnabled
+    @AppStorage(MobileSettingsKeys.cwlWindowDays) private var cwlWindowDays = MobileSettingsDefaults.cwlWindowDays
     @State private var showClearLedgerConfirm = false
 
     var body: some View {
@@ -3605,7 +3814,10 @@ private struct CostSettingsView: View {
                 Toggle(isOn: self.$cwlEnabled) {
                     VStack(alignment: .leading, spacing: 4) {
                         Text("Local cost history")
-                        Text("Keep a longer cost history on this iPhone, independent of the Mac's window. Builds up as the Mac keeps syncing.")
+                        Text("Off uses the latest synced Mac snapshots and the Mac history window.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text("On keeps synced daily cost points on this iPhone for the selected window. It still requires Mac sync and never reads Mac logs directly.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -393,18 +393,28 @@ enum CostTabInsightsResolver {
         ledgerAggregation: CostLedgerAggregation?,
         isLedgerEnabled: Bool,
         isDemoMode: Bool,
-        localHistoryClearedAt: Date?) -> CostDashboardInsights?
+        localHistoryClearedAt: Date?,
+        ledgerWindowDays: Int? = nil) -> CostDashboardInsights?
     {
         let insights: CostDashboardInsights
-        if isLedgerEnabled, !isDemoMode, let aggregation = ledgerAggregation {
-            if aggregation.hasDisplayData {
-                insights = CostDashboardInsights.fromLedger(
-                    aggregation: aggregation,
-                    snapshot: snapshot,
-                    snapshotFallbackCutoff: localHistoryClearedAt)
+        if isLedgerEnabled, !isDemoMode {
+            if let aggregation = ledgerAggregation {
+                if aggregation.hasDisplayData {
+                    insights = CostDashboardInsights.fromLedger(
+                        aggregation: aggregation,
+                        snapshot: snapshot,
+                        snapshotFallbackCutoff: localHistoryClearedAt)
+                } else if localHistoryClearedAt != nil {
+                    insights = CostDashboardInsights.fromLedger(
+                        aggregation: aggregation,
+                        snapshot: snapshot,
+                        snapshotFallbackCutoff: localHistoryClearedAt)
+                } else {
+                    insights = CostDashboardInsights(snapshot: snapshot)
+                }
             } else if localHistoryClearedAt != nil {
                 insights = CostDashboardInsights.fromLedger(
-                    aggregation: aggregation,
+                    aggregation: self.emptyAggregation(windowDays: ledgerWindowDays ?? 30),
                     snapshot: snapshot,
                     snapshotFallbackCutoff: localHistoryClearedAt)
             } else {
@@ -414,6 +424,18 @@ enum CostTabInsightsResolver {
             insights = CostDashboardInsights(snapshot: snapshot)
         }
         return insights.hasDisplayData ? insights : nil
+    }
+
+    private static func emptyAggregation(windowDays: Int) -> CostLedgerAggregation {
+        CostLedgerAggregation(
+            windowDays: windowDays,
+            totalCostUSD: 0,
+            totalTokens: 0,
+            activeDayCount: 0,
+            providerRollups: [:],
+            dailyPoints: [],
+            modelMix: [],
+            serviceMix: [])
     }
 }
 
@@ -432,7 +454,8 @@ enum CostDiagnosticsReportResolver {
             ledgerAggregation: ledgerAggregation,
             isLedgerEnabled: cwlEnabled,
             isDemoMode: false,
-            localHistoryClearedAt: localHistoryClearedAt)
+            localHistoryClearedAt: localHistoryClearedAt,
+            ledgerWindowDays: cwlWindowDays)
         else {
             return nil
         }
@@ -489,7 +512,8 @@ private struct CostTab: View {
             ledgerAggregation: aggregation,
             isLedgerEnabled: self.cwlEnabled,
             isDemoMode: self.isDemoMode,
-            localHistoryClearedAt: CostLedgerService.blobSeedClearTombstoneDate())
+            localHistoryClearedAt: CostLedgerService.blobSeedClearTombstoneDate(),
+            ledgerWindowDays: self.cwlWindowDays)
     }
 
     private var activeDeviceIDsForLedger: Set<String>? {

--- a/CodexBarMobile/CodexBarMobile/ContentView.swift
+++ b/CodexBarMobile/CodexBarMobile/ContentView.swift
@@ -1188,6 +1188,24 @@ struct CostDashboardInsights {
         let date: Date
         let costUSD: Double
         let totalTokens: Int
+        let modelBreakdowns: [SyncCostBreakdown]
+        let serviceBreakdowns: [SyncCostBreakdown]
+
+        init(
+            dayKey: String,
+            date: Date,
+            costUSD: Double,
+            totalTokens: Int,
+            modelBreakdowns: [SyncCostBreakdown] = [],
+            serviceBreakdowns: [SyncCostBreakdown] = [])
+        {
+            self.dayKey = dayKey
+            self.date = date
+            self.costUSD = costUSD
+            self.totalTokens = totalTokens
+            self.modelBreakdowns = modelBreakdowns
+            self.serviceBreakdowns = serviceBreakdowns
+        }
 
         var id: String {
             self.dayKey
@@ -1264,7 +1282,7 @@ struct CostDashboardInsights {
 
     init(snapshot: SyncedUsageSnapshot) {
         var providerRows: [ProviderRow] = []
-        var dailyTotals: [String: (costUSD: Double, totalTokens: Int)] = [:]
+        var dailyTotals: [String: DailyAccumulator] = [:]
         var modelTotals: [String: Double] = [:]
         // Codex standard/fast split summed per model across the window, so the
         // Model Mix rows can show a "Std / Fast" sub-line (upstream #1070).
@@ -1307,8 +1325,7 @@ struct CostDashboardInsights {
                     dailyPoints: providerDailyPoints))
 
             for point in costSummary.daily {
-                dailyTotals[point.dayKey, default: (0, 0)].costUSD += point.costUSD
-                dailyTotals[point.dayKey, default: (0, 0)].totalTokens += point.totalTokens
+                dailyTotals[point.dayKey, default: .init()].ingest(point)
 
                 for breakdown in point.modelBreakdowns where breakdown.costUSD > 0 {
                     modelTotals[breakdown.label, default: 0] += breakdown.costUSD
@@ -1335,7 +1352,7 @@ struct CostDashboardInsights {
         self.dailyPoints = dailyTotals.keys.compactMap { dayKey in
             guard let date = Self.dayKeyFormatter.date(from: dayKey),
                   let totals = dailyTotals[dayKey] else { return nil }
-            return DailyPoint(dayKey: dayKey, date: date, costUSD: totals.costUSD, totalTokens: totals.totalTokens)
+            return totals.dailyPoint(dayKey: dayKey, date: date)
         }
         .sorted { $0.date < $1.date }
 
@@ -1389,10 +1406,10 @@ struct CostDashboardInsights {
 
         var providerRows: [ProviderRow] = []
         var representedProviderKeys = Set<String>()
-        var dailyTotals = Dictionary(
-            uniqueKeysWithValues: aggregation.dailyPoints.map { point in
-                (point.dayKey, (costUSD: point.costUSD, totalTokens: point.totalTokens))
-            })
+        var dailyTotals: [String: DailyAccumulator] = [:]
+        for point in aggregation.dailyPoints {
+            dailyTotals[point.dayKey, default: .init()].ingest(point)
+        }
         var modelTotals = Dictionary(
             uniqueKeysWithValues: aggregation.modelMix.map { ($0.label, $0.costUSD) })
         var modelSplits = Dictionary(
@@ -1468,8 +1485,7 @@ struct CostDashboardInsights {
                 dailyPoints: providerDailyPoints))
 
             for point in fallbackSyncPoints {
-                dailyTotals[point.dayKey, default: (0, 0)].costUSD += point.costUSD
-                dailyTotals[point.dayKey, default: (0, 0)].totalTokens += point.totalTokens
+                dailyTotals[point.dayKey, default: .init()].ingest(point)
 
                 for breakdown in point.modelBreakdowns where breakdown.costUSD > 0 {
                     modelTotals[breakdown.label, default: 0] += breakdown.costUSD
@@ -1495,11 +1511,7 @@ struct CostDashboardInsights {
         let dailyPoints: [DailyPoint] = dailyTotals.keys.compactMap { dayKey in
             guard let date = Self.dayKeyFormatter.date(from: dayKey),
                   let totals = dailyTotals[dayKey] else { return nil }
-            return DailyPoint(
-                dayKey: dayKey,
-                date: date,
-                costUSD: totals.costUSD,
-                totalTokens: totals.totalTokens)
+            return totals.dailyPoint(dayKey: dayKey, date: date)
         }
 
         return CostDashboardInsights(
@@ -1579,7 +1591,95 @@ struct CostDashboardInsights {
             dayKey: point.dayKey,
             date: date,
             costUSD: point.costUSD,
-            totalTokens: point.totalTokens)
+            totalTokens: point.totalTokens,
+            modelBreakdowns: point.modelBreakdowns,
+            serviceBreakdowns: point.serviceBreakdowns)
+    }
+
+    private struct DailyAccumulator {
+        var costUSD: Double = 0
+        var totalTokens: Int = 0
+        var modelBreakdowns: [String: BreakdownAccumulator] = [:]
+        var serviceBreakdowns: [String: BreakdownAccumulator] = [:]
+
+        mutating func ingest(_ point: SyncDailyPoint) {
+            self.costUSD += point.costUSD
+            self.totalTokens += point.totalTokens
+            for breakdown in point.modelBreakdowns {
+                self.modelBreakdowns[breakdown.label, default: .init()].ingest(breakdown)
+            }
+            for breakdown in point.serviceBreakdowns {
+                self.serviceBreakdowns[breakdown.label, default: .init()].ingest(breakdown)
+            }
+        }
+
+        func dailyPoint(dayKey: String, date: Date) -> DailyPoint {
+            DailyPoint(
+                dayKey: dayKey,
+                date: date,
+                costUSD: self.costUSD,
+                totalTokens: self.totalTokens,
+                modelBreakdowns: Self.sortedBreakdowns(self.modelBreakdowns),
+                serviceBreakdowns: Self.sortedBreakdowns(self.serviceBreakdowns))
+        }
+
+        private static func sortedBreakdowns(
+            _ totals: [String: BreakdownAccumulator]
+        ) -> [SyncCostBreakdown] {
+            totals
+                .map { label, accumulator in accumulator.breakdown(label: label) }
+                .sorted { lhs, rhs in
+                    if lhs.costUSD == rhs.costUSD {
+                        return lhs.label.localizedCaseInsensitiveCompare(rhs.label) == .orderedAscending
+                    }
+                    return lhs.costUSD > rhs.costUSD
+                }
+        }
+    }
+
+    private struct BreakdownAccumulator {
+        var costUSD: Double = 0
+        var isEstimated = false
+        var standardCostUSD: Double = 0
+        var priorityCostUSD: Double = 0
+        var standardTokens: Int = 0
+        var priorityTokens: Int = 0
+        var hasStandardCost = false
+        var hasPriorityCost = false
+        var hasStandardTokens = false
+        var hasPriorityTokens = false
+
+        mutating func ingest(_ breakdown: SyncCostBreakdown) {
+            self.costUSD += breakdown.costUSD
+            self.isEstimated = self.isEstimated || breakdown.isEstimated == true
+            if let standardCostUSD = breakdown.standardCostUSD {
+                self.standardCostUSD += standardCostUSD
+                self.hasStandardCost = true
+            }
+            if let priorityCostUSD = breakdown.priorityCostUSD {
+                self.priorityCostUSD += priorityCostUSD
+                self.hasPriorityCost = true
+            }
+            if let standardTokens = breakdown.standardTokens {
+                self.standardTokens += standardTokens
+                self.hasStandardTokens = true
+            }
+            if let priorityTokens = breakdown.priorityTokens {
+                self.priorityTokens += priorityTokens
+                self.hasPriorityTokens = true
+            }
+        }
+
+        func breakdown(label: String) -> SyncCostBreakdown {
+            SyncCostBreakdown(
+                label: label,
+                costUSD: self.costUSD,
+                isEstimated: self.isEstimated ? true : nil,
+                standardCostUSD: self.hasStandardCost ? self.standardCostUSD : nil,
+                priorityCostUSD: self.hasPriorityCost ? self.priorityCostUSD : nil,
+                standardTokens: self.hasStandardTokens ? self.standardTokens : nil,
+                priorityTokens: self.hasPriorityTokens ? self.priorityTokens : nil)
+        }
     }
 
     /// Wire-format `dayKey` formatter used to match records to today's

--- a/CodexBarMobile/CodexBarMobile/Localizable.xcstrings
+++ b/CodexBarMobile/CodexBarMobile/Localizable.xcstrings
@@ -8919,30 +8919,30 @@
         }
       }
     },
-    "These tools expose internal sync and notification state to help diagnose issues. No sensitive data is shown.": {
+    "These tools may show internal sync state, device identifiers, and account emails for debugging.": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "These tools expose internal sync and notification state to help diagnose issues. No sensitive data is shown."
+            "value": "These tools may show internal sync state, device identifiers, and account emails for debugging."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "これらのツールは内部の同期および通知の状態を表示し、問題の診断に役立ちます。機密データは表示されません。"
+            "value": "これらのツールは、デバッグのために内部同期状態、デバイス識別子、アカウントのメールアドレスを表示することがあります。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "这些工具用于查看内部同步和通知状态以帮助排查问题，不会显示任何敏感信息。"
+            "value": "这些工具可能会显示内部同步状态、设备标识符和账号邮箱，用于排查问题。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "這些工具用於查看內部同步和通知狀態以協助排查問題，不會顯示任何敏感資訊。"
+            "value": "這些工具可能會顯示內部同步狀態、裝置識別碼和帳號信箱，用於排查問題。"
           }
         }
       }

--- a/CodexBarMobile/CodexBarMobile/Localizable.xcstrings
+++ b/CodexBarMobile/CodexBarMobile/Localizable.xcstrings
@@ -18240,6 +18240,93 @@
         }
       }
     },
+    "Cost history defaults — Local cost history now starts on with a 90-day window, and Cost Settings explains how it differs from the synced Mac snapshot path.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cost history defaults — Local cost history now starts on with a 90-day window, and Cost Settings explains how it differs from the synced Mac snapshot path."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コスト履歴の既定値 — ローカルコスト履歴は既定でオンになり、90日間のウィンドウを使います。Cost設定では、同期済みMacスナップショット経路との違いも説明します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cost 历史默认值 —— 本地成本历史现在默认开启，窗口为 90 天；Cost 设置会说明它和已同步 Mac 快照路径的区别。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cost 歷史預設值 —— 本機成本歷史現在預設開啟，視窗為 90 天；Cost 設定會說明它和已同步 Mac 快照路徑的差異。"
+          }
+        }
+      }
+    },
+    "Cost diagnostics — Developer Tools can now show the source path, provider rules, and reconciliation checks behind the Cost totals.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cost diagnostics — Developer Tools can now show the source path, provider rules, and reconciliation checks behind the Cost totals."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コスト診断 — Developer Tools で、Cost合計の背後にあるソース経路、プロバイダールール、照合チェックを確認できます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cost 诊断 —— Developer Tools 现在可以显示 Cost 总额背后的数据来源、provider 规则和对账检查。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cost 診斷 —— Developer Tools 現在可以顯示 Cost 總額背後的資料來源、provider 規則和對帳檢查。"
+          }
+        }
+      }
+    },
+    "Widget polish — updated timestamps are centered across every widget size and mode.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Widget polish — updated timestamps are centered across every widget size and mode."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィジェットの調整 — 更新時刻は、すべてのウィジェットサイズとモードで中央揃えになりました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小组件细节优化 —— 更新时间现在会在每一种小组件尺寸和模式中居中显示。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小工具細節最佳化 —— 更新時間現在會在每一種小工具尺寸和模式中置中顯示。"
+          }
+        }
+      }
+    },
     "Provider fixes included — the companion app understands the latest Mac data for Sakana AI quotas, Qoder credits, ClawRouter budget usage, CrossModel wallet usage, and upstream menu/provider reliability fixes.": {
       "extractionState": "manual",
       "localizations": {
@@ -18294,6 +18381,847 @@
           "stringUnit": {
             "state": "translated",
             "value": "請將 Mac CodexBar 更新到 0.39.0.1（fork build 97.1 或更高版本）以獲得完整的 1.17 體驗。iPhone 1.17.0 仍可打開舊版 Mac 資料；更新 Mac 後才會顯示新的 provider 詳情。"
+          }
+        }
+      }
+    },
+    "%d days": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d days"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d 日"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d 天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d 天"
+          }
+        }
+      }
+    },
+    "7-day provider difference %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7-day provider difference %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7日間のプロバイダー差分 %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 天 provider 差异 %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 天 provider 差異 %@"
+          }
+        }
+      }
+    },
+    "Active Devices": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active Devices"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクティブなデバイス"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "活跃设备"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "活躍裝置"
+          }
+        }
+      }
+    },
+    "Audit Cost totals and merge rules": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audit Cost totals and merge rules"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cost 合計とマージ規則を監査"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "审计 Cost 总额和合并规则"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稽核 Cost 總額和合併規則"
+          }
+        }
+      }
+    },
+    "Cost Diagnostics": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cost Diagnostics"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cost 診断"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cost 诊断"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cost 診斷"
+          }
+        }
+      }
+    },
+    "Covers %.0f%% of total": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Covers %.0f%% of total"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "合計の %.0f%% をカバー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "覆盖总额的 %.0f%%"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "涵蓋總額的 %.0f%%"
+          }
+        }
+      }
+    },
+    "Difference %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Difference %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "差分 %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "差异 %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "差異 %@"
+          }
+        }
+      }
+    },
+    "Excluded Devices": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluded Devices"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "除外されたデバイス"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已排除设备"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已排除裝置"
+          }
+        }
+      }
+    },
+    "Inspect per-device synced rows used as source input": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inspect per-device synced rows used as source input"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "入力元として使われたデバイス別同期行を確認"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看作为源输入的每台设备同步行"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢視作為來源輸入的每台裝置同步列"
+          }
+        }
+      }
+    },
+    "Matches Overview total": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Matches Overview total"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Overview 合計と一致"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匹配 Overview 总额"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "符合 Overview 總額"
+          }
+        }
+      }
+    },
+    "No breakdown data": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No breakdown data"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内訳データなし"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有细分数据"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有細分資料"
+          }
+        }
+      }
+    },
+    "No cost data available": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No cost data available"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用可能な Cost データがありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可用 Cost 数据"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有可用 Cost 資料"
+          }
+        }
+      }
+    },
+    "No cost total": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No cost total"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コスト合計なし"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有成本总额"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有成本總額"
+          }
+        }
+      }
+    },
+    "Off uses the latest synced Mac snapshots and the Mac history window.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off uses the latest synced Mac snapshots and the Mac history window."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフの場合は、最新の同期済み Mac snapshot と Mac の履歴期間を使います。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭时使用最新同步的 Mac snapshot，并跟随 Mac 历史窗口。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉時使用最新同步的 Mac snapshot，並跟隨 Mac 歷史視窗。"
+          }
+        }
+      }
+    },
+    "On keeps synced daily cost points on this iPhone for the selected window. It still requires Mac sync and never reads Mac logs directly.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "On keeps synced daily cost points on this iPhone for the selected window. It still requires Mac sync and never reads Mac logs directly."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オンの場合、この iPhone に同期済みの日別 Cost 点を保存し、選択した期間で表示します。Mac 同期は引き続き必要で、Mac のログを直接読むことはありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开启时会在这台 iPhone 上保存已同步的每日 cost 点，并按所选窗口显示。它仍然需要 Mac 同步，不会直接读取 Mac 日志。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟時會在這台 iPhone 上保存已同步的每日 cost 點，並按所選視窗顯示。它仍然需要 Mac 同步，不會直接讀取 Mac 日誌。"
+          }
+        }
+      }
+    },
+    "Open Raw Sync Data": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Raw Sync Data"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raw Sync Data を開く"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 Raw Sync Data"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打開 Raw Sync Data"
+          }
+        }
+      }
+    },
+    "Provider Rules": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provider Rules"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロバイダー規則"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provider 规则"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provider 規則"
+          }
+        }
+      }
+    },
+    "Raw Inputs": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raw Inputs"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raw 入力"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "原始输入"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "原始輸入"
+          }
+        }
+      }
+    },
+    "Reconciliation": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconciliation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "照合"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致性校验"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致性校驗"
+          }
+        }
+      }
+    },
+    "Share Card": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share Card"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "共有カード"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分享卡"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分享卡"
+          }
+        }
+      }
+    },
+    "Source": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソース"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "数据源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "資料來源"
+          }
+        }
+      }
+    },
+    "Summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Summary"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "概要"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "摘要"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "摘要"
+          }
+        }
+      }
+    },
+    "Synced Snapshots": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synced Snapshots"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同期済み Snapshots"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已同步 Snapshots"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已同步 Snapshots"
+          }
+        }
+      }
+    },
+    "Synced Snapshots (ledger unavailable)": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synced Snapshots (ledger unavailable)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同期済み Snapshots（台帳を利用できません）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已同步 Snapshots（账本不可用）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已同步 Snapshots（帳本不可用）"
+          }
+        }
+      }
+    },
+    "Total Cost": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Total Cost"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "合計コスト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "总成本"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "總成本"
+          }
+        }
+      }
+    },
+    "Uses exact provider daily points": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uses exact provider daily points"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正確なプロバイダー日別点を使用"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用精确的 provider 每日点"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用精確的 provider 每日點"
+          }
+        }
+      }
+    },
+    "Window": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Window"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "期間"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "窗口"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "視窗"
+          }
+        }
+      }
+    },
+    "latest account/day row": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "latest account/day row"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新のアカウント/日付行"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新账号/日期行"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新帳號/日期列"
+          }
+        }
+      }
+    },
+    "sum active devices": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sum active devices"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクティブなデバイスを合算"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "汇总活跃设备"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "彙總活躍裝置"
           }
         }
       }

--- a/CodexBarMobile/CodexBarMobile/Localizable.xcstrings
+++ b/CodexBarMobile/CodexBarMobile/Localizable.xcstrings
@@ -18762,6 +18762,35 @@
         }
       }
     },
+    "None": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "None"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "なし"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無"
+          }
+        }
+      }
+    },
     "Off uses the latest synced Mac snapshots and the Mac history window.": {
       "extractionState": "manual",
       "localizations": {

--- a/CodexBarMobile/CodexBarMobile/Models/CostDiagnosticsReport.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/CostDiagnosticsReport.swift
@@ -142,10 +142,15 @@ struct CostDiagnosticsReport: Equatable {
                 overviewTotal: totalCost,
                 compareMonthlyToOverview: (insights.historyDays ?? 30) <= 30),
         ]
+        let windowDays = if dataSource == .localLedger {
+            insights.historyDays ?? cwlWindowDays
+        } else {
+            insights.historyDays ?? 30
+        }
 
         return CostDiagnosticsReport(
             dataSource: dataSource,
-            windowDays: insights.historyDays ?? cwlWindowDays,
+            windowDays: windowDays,
             totalCostUSD: totalCost,
             todayCostUSD: insights.totalTodayCost,
             totalTokens: insights.total30DayTokens,

--- a/CodexBarMobile/CodexBarMobile/Models/CostDiagnosticsReport.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/CostDiagnosticsReport.swift
@@ -1,0 +1,218 @@
+import CodexBarSync
+import Foundation
+
+enum CostDiagnosticsDataSource: Equatable {
+    case localLedger
+    case syncedSnapshots
+    case syncedSnapshotsAfterLedgerFailure
+}
+
+enum CostDiagnosticsMergeRule: Equatable {
+    case sumActiveDevices
+    case latestAccountDay
+}
+
+enum CostDiagnosticsStatus: Equatable {
+    case pass
+    case warning
+    case unavailable
+}
+
+enum CostDiagnosticsCheckKind: String, Equatable {
+    case providerShare
+    case dailySpend
+    case modelMix
+    case serviceMix
+    case shareCard
+}
+
+enum CostDiagnosticsCheckDetail: Equatable {
+    case matchesOverviewTotal
+    case difference(Double)
+    case covers(Double)
+    case noCostTotal
+    case noBreakdownData
+    case usesExactProviderDailyPoints
+    case sevenDayProviderDifference(Double)
+}
+
+struct CostDiagnosticsProviderRule: Identifiable, Equatable {
+    let ordinal: Int
+    let providerID: String
+    let providerName: String
+    let accountEmail: String?
+    let rule: CostDiagnosticsMergeRule
+
+    var id: String {
+        "\(self.providerID)|\(self.accountEmail ?? "_")|\(self.ordinal)"
+    }
+}
+
+struct CostDiagnosticsCheck: Identifiable, Equatable {
+    let kind: CostDiagnosticsCheckKind
+    let detail: CostDiagnosticsCheckDetail
+    let status: CostDiagnosticsStatus
+
+    var id: String {
+        self.kind.rawValue
+    }
+}
+
+struct CostDiagnosticsReport: Equatable {
+    let dataSource: CostDiagnosticsDataSource
+    let windowDays: Int
+    let totalCostUSD: Double
+    let todayCostUSD: Double
+    let totalTokens: Int
+    let activeDayCount: Int
+    let topDriverName: String?
+    let topDriverCostUSD: Double?
+    let rawDeviceCount: Int
+    let activeDeviceCount: Int
+    let excludedDeviceCount: Int
+    let providerRules: [CostDiagnosticsProviderRule]
+    let checks: [CostDiagnosticsCheck]
+
+    static func make(
+        insights: CostDashboardInsights,
+        snapshot: SyncedUsageSnapshot,
+        rawDeviceSnapshots: [SyncedUsageSnapshot],
+        activeDeviceSnapshots: [SyncedUsageSnapshot],
+        cwlEnabled: Bool,
+        cwlWindowDays: Int,
+        ledgerAvailable: Bool) -> CostDiagnosticsReport
+    {
+        let dataSource: CostDiagnosticsDataSource = if cwlEnabled {
+            ledgerAvailable ? .localLedger : .syncedSnapshotsAfterLedgerFailure
+        } else {
+            .syncedSnapshots
+        }
+
+        let providersWithCost = MockProviderDetector.filteredProviders(from: snapshot)
+            .filter { $0.costSummary != nil }
+            .sorted { lhs, rhs in
+                if lhs.providerName == rhs.providerName {
+                    return (lhs.accountEmail ?? "") < (rhs.accountEmail ?? "")
+                }
+                return lhs.providerName.localizedCaseInsensitiveCompare(rhs.providerName) == .orderedAscending
+            }
+        let providerRules = providersWithCost
+            .enumerated()
+            .map { offset, provider in
+                CostDiagnosticsProviderRule(
+                    ordinal: offset,
+                    providerID: provider.providerID,
+                    providerName: provider.providerName,
+                    accountEmail: provider.accountEmail,
+                    rule: ProviderSnapshotMerger.usesLocalCostMerge(providerID: provider.providerID)
+                        ? .sumActiveDevices
+                        : .latestAccountDay)
+            }
+
+        let totalCost = insights.total30DayCost
+        let providerShareTotal = insights.spendProviderRows.reduce(0) { $0 + $1.thirtyDayCost }
+        let dailyTotal = insights.dailyPoints.reduce(0) { $0 + $1.costUSD }
+        let modelTotal = insights.modelRows.reduce(0) { $0 + $1.amountUSD }
+        let serviceTotal = insights.serviceRows.reduce(0) { $0 + $1.amountUSD }
+        let weeklyShareCard = ShareCardData(insights: insights, period: .week)
+        let monthlyShareCard = ShareCardData(insights: insights, period: .month)
+
+        let checks = [
+            Self.moneyCheck(
+                kind: .providerShare,
+                expected: totalCost,
+                actual: providerShareTotal,
+                passDetail: .matchesOverviewTotal),
+            Self.moneyCheck(
+                kind: .dailySpend,
+                expected: totalCost,
+                actual: dailyTotal,
+                passDetail: .matchesOverviewTotal),
+            Self.coverageCheck(
+                kind: .modelMix,
+                total: totalCost,
+                covered: modelTotal),
+            Self.coverageCheck(
+                kind: .serviceMix,
+                total: totalCost,
+                covered: serviceTotal),
+            Self.shareCardCheck(
+                weekly: weeklyShareCard,
+                monthly: monthlyShareCard,
+                overviewTotal: totalCost),
+        ]
+
+        return CostDiagnosticsReport(
+            dataSource: dataSource,
+            windowDays: insights.historyDays ?? cwlWindowDays,
+            totalCostUSD: totalCost,
+            todayCostUSD: insights.totalTodayCost,
+            totalTokens: insights.total30DayTokens,
+            activeDayCount: insights.activeDayCount,
+            topDriverName: insights.topProvider?.provider.providerName,
+            topDriverCostUSD: insights.topProvider?.thirtyDayCost,
+            rawDeviceCount: rawDeviceSnapshots.count,
+            activeDeviceCount: activeDeviceSnapshots.count,
+            excludedDeviceCount: max(0, rawDeviceSnapshots.count - activeDeviceSnapshots.count),
+            providerRules: providerRules,
+            checks: checks)
+    }
+
+    private static func moneyCheck(
+        kind: CostDiagnosticsCheckKind,
+        expected: Double,
+        actual: Double,
+        passDetail: CostDiagnosticsCheckDetail) -> CostDiagnosticsCheck
+    {
+        let delta = abs(expected - actual)
+        if delta < 0.01 {
+            return CostDiagnosticsCheck(kind: kind, detail: passDetail, status: .pass)
+        }
+        return CostDiagnosticsCheck(
+            kind: kind,
+            detail: .difference(delta),
+            status: .warning)
+    }
+
+    private static func coverageCheck(
+        kind: CostDiagnosticsCheckKind,
+        total: Double,
+        covered: Double) -> CostDiagnosticsCheck
+    {
+        guard total > 0 else {
+            return CostDiagnosticsCheck(kind: kind, detail: .noCostTotal, status: .unavailable)
+        }
+        if covered <= 0 {
+            return CostDiagnosticsCheck(kind: kind, detail: .noBreakdownData, status: .unavailable)
+        }
+        let clamped = min(max(covered / total, 0), 1)
+        return CostDiagnosticsCheck(
+            kind: kind,
+            detail: .covers(clamped),
+            status: covered <= total + 0.01 ? .pass : .warning)
+    }
+
+    private static func shareCardCheck(
+        weekly: ShareCardData,
+        monthly: ShareCardData,
+        overviewTotal: Double) -> CostDiagnosticsCheck
+    {
+        guard abs(monthly.totalCost - overviewTotal) < 0.01 else {
+            return CostDiagnosticsCheck(
+                kind: .shareCard,
+                detail: .difference(abs(monthly.totalCost - overviewTotal)),
+                status: .warning)
+        }
+        let weeklyProviderTotal = weekly.providers.reduce(0) { $0 + $1.cost }
+        guard abs(weeklyProviderTotal - weekly.totalCost) < 0.01 else {
+            return CostDiagnosticsCheck(
+                kind: .shareCard,
+                detail: .sevenDayProviderDifference(abs(weeklyProviderTotal - weekly.totalCost)),
+                status: .warning)
+        }
+        return CostDiagnosticsCheck(
+            kind: .shareCard,
+            detail: .usesExactProviderDailyPoints,
+            status: .pass)
+    }
+}

--- a/CodexBarMobile/CodexBarMobile/Models/CostDiagnosticsReport.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/CostDiagnosticsReport.swift
@@ -140,7 +140,7 @@ struct CostDiagnosticsReport: Equatable {
                 weekly: weeklyShareCard,
                 monthly: monthlyShareCard,
                 overviewTotal: totalCost,
-                compareMonthlyToOverview: (insights.historyDays ?? 30) <= 30),
+                compareMonthlyToOverview: (insights.historyDays ?? 30) == 30),
         ]
         let windowDays = if dataSource == .localLedger {
             insights.historyDays ?? cwlWindowDays

--- a/CodexBarMobile/CodexBarMobile/Models/CostDiagnosticsReport.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/CostDiagnosticsReport.swift
@@ -139,7 +139,8 @@ struct CostDiagnosticsReport: Equatable {
             Self.shareCardCheck(
                 weekly: weeklyShareCard,
                 monthly: monthlyShareCard,
-                overviewTotal: totalCost),
+                overviewTotal: totalCost,
+                compareMonthlyToOverview: (insights.historyDays ?? 30) <= 30),
         ]
 
         return CostDiagnosticsReport(
@@ -195,9 +196,10 @@ struct CostDiagnosticsReport: Equatable {
     private static func shareCardCheck(
         weekly: ShareCardData,
         monthly: ShareCardData,
-        overviewTotal: Double) -> CostDiagnosticsCheck
+        overviewTotal: Double,
+        compareMonthlyToOverview: Bool) -> CostDiagnosticsCheck
     {
-        guard abs(monthly.totalCost - overviewTotal) < 0.01 else {
+        if compareMonthlyToOverview, abs(monthly.totalCost - overviewTotal) >= 0.01 {
             return CostDiagnosticsCheck(
                 kind: .shareCard,
                 detail: .difference(abs(monthly.totalCost - overviewTotal)),

--- a/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
@@ -171,15 +171,25 @@ extension ShareCardData {
             row.dailyPoints.filter { $0.date >= monthStart && $0.date < tomorrow }
         }
 
+        let dayKeyFormatter = SyncCostSummary.iso8601DayKeyFormatter()
+
         func authoritativeThirtyDaySummary(for row: CostDashboardInsights.ProviderRow) -> (costUSD: Double?, tokens: Int?) {
             guard let summary = row.provider.costSummary else {
                 return (nil, nil)
             }
             let summaryWindowDays = max(1, min(summary.historyDays ?? 30, 365))
-            guard summaryWindowDays <= 30 else {
-                return (nil, nil)
+            let monthlyPoints = summary.daily.filter { point in
+                guard let date = dayKeyFormatter.date(from: point.dayKey) else { return false }
+                return date >= monthStart && date < tomorrow
             }
-            return (summary.last30DaysCostUSD, summary.last30DaysTokens)
+            let dailyCost = monthlyPoints.isEmpty ? nil : monthlyPoints.reduce(0) { $0 + $1.costUSD }
+            let dailyTokens = monthlyPoints.isEmpty ? nil : monthlyPoints.reduce(0) { $0 + $1.totalTokens }
+            guard summaryWindowDays <= 30 else {
+                return (dailyCost, dailyTokens)
+            }
+            return (
+                summary.last30DaysCostUSD ?? dailyCost,
+                summary.last30DaysTokens ?? dailyTokens)
         }
 
         func monthlyCost(for row: CostDashboardInsights.ProviderRow) -> Double {
@@ -197,8 +207,6 @@ extension ShareCardData {
             }
             return max(dailyTokens, summaryTokens)
         }
-
-        let dayKeyFormatter = SyncCostSummary.iso8601DayKeyFormatter()
 
         func costSummaryPoints(
             for row: CostDashboardInsights.ProviderRow,
@@ -218,11 +226,24 @@ extension ShareCardData {
             }
         }
 
-        func monthlySummaryDailyPoints() -> [CostDashboardInsights.DailyPoint] {
+        func monthlySummaryDisplayData() -> (
+            dailyPoints: [CostDashboardInsights.DailyPoint],
+            modelBreakdowns: [SyncCostBreakdown]
+        ) {
             var totals: [String: (date: Date, costUSD: Double, totalTokens: Int)] = [:]
-            func addDay(dayKey: String, date: Date, costUSD: Double, totalTokens: Int) {
+            var modelTotals: [String: Double] = [:]
+            func addDay(
+                dayKey: String,
+                date: Date,
+                costUSD: Double,
+                totalTokens: Int,
+                modelBreakdowns: [SyncCostBreakdown])
+            {
                 totals[dayKey, default: (date, 0, 0)].costUSD += costUSD
                 totals[dayKey, default: (date, 0, 0)].totalTokens += totalTokens
+                for breakdown in modelBreakdowns where breakdown.costUSD > 0 {
+                    modelTotals[breakdown.label, default: 0] += breakdown.costUSD
+                }
             }
             for row in insights.providerRows {
                 if row.provider.costSummary == nil {
@@ -231,7 +252,8 @@ extension ShareCardData {
                             dayKey: point.dayKey,
                             date: point.date,
                             costUSD: point.costUSD,
-                            totalTokens: point.totalTokens)
+                            totalTokens: point.totalTokens,
+                            modelBreakdowns: point.modelBreakdowns)
                     }
                 } else {
                     for point in costSummaryPoints(for: row, period: .month) {
@@ -240,11 +262,12 @@ extension ShareCardData {
                             dayKey: point.dayKey,
                             date: date,
                             costUSD: point.costUSD,
-                            totalTokens: point.totalTokens)
+                            totalTokens: point.totalTokens,
+                            modelBreakdowns: point.modelBreakdowns)
                     }
                 }
             }
-            return totals
+            let dailyPoints = totals
                 .map { dayKey, total in
                     CostDashboardInsights.DailyPoint(
                         dayKey: dayKey,
@@ -253,13 +276,32 @@ extension ShareCardData {
                         totalTokens: total.totalTokens)
                 }
                 .sorted { $0.date < $1.date }
+            let modelBreakdowns = modelTotals
+                .map { SyncCostBreakdown(label: $0.key, costUSD: $0.value) }
+                .sorted {
+                    if $0.costUSD == $1.costUSD {
+                        return $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending
+                    }
+                    return $0.costUSD > $1.costUSD
+                }
+            return (dailyPoints, modelBreakdowns)
         }
 
-        func modelRows(for period: SharePeriod) -> [BreakdownRow] {
+        func modelRows(
+            for period: SharePeriod,
+            monthlyUsesProviderSummary: Bool,
+            monthlySummaryModelBreakdowns: [SyncCostBreakdown]
+        ) -> [BreakdownRow] {
             var totals: [String: Double] = [:]
-            for point in filteredDays {
-                for breakdown in point.modelBreakdowns where breakdown.costUSD > 0 {
+            if period == .month, monthlyUsesProviderSummary {
+                for breakdown in monthlySummaryModelBreakdowns where breakdown.costUSD > 0 {
                     totals[breakdown.label, default: 0] += breakdown.costUSD
+                }
+            } else {
+                for point in filteredDays {
+                    for breakdown in point.modelBreakdowns where breakdown.costUSD > 0 {
+                        totals[breakdown.label, default: 0] += breakdown.costUSD
+                    }
                 }
             }
             let periodDays: Int = switch period {
@@ -267,7 +309,11 @@ extension ShareCardData {
             case .week: 7
             case .month: 30
             }
-            if totals.isEmpty, (insights.historyDays ?? 30) <= periodDays {
+            let usesDashboardWindow = period != .month || !monthlyUsesProviderSummary
+            if totals.isEmpty,
+               usesDashboardWindow,
+               (insights.historyDays ?? 30) <= periodDays
+            {
                 let fallbackRows = insights.modelRows
                     .filter { $0.amountUSD > 0 }
                     .sorted {
@@ -311,7 +357,8 @@ extension ShareCardData {
         // Compute totals
         let periodCost: Double
         let periodTokens: Int
-        let monthlySummaryDays = monthlySummaryDailyPoints()
+        let monthlySummaryData = monthlySummaryDisplayData()
+        let monthlySummaryDays = monthlySummaryData.dailyPoints
         let monthlyUsesProviderSummary: Bool
         switch period {
         case .today:
@@ -331,7 +378,14 @@ extension ShareCardData {
             let providerTokens = insights.providerRows.reduce(0) { $0 + monthlyTokens(for: $1) }
             let dailyTokens = filteredDays.reduce(0) { $0 + $1.totalTokens }
             periodTokens = providerTokens > 0 ? providerTokens : dailyTokens
-            monthlyUsesProviderSummary = providerCost > dailyCost || providerTokens > dailyTokens
+            let summaryExtendsShortDashboardWindow = (insights.historyDays ?? 30) < 30
+                && insights.providerRows.contains { row in
+                    let summary = authoritativeThirtyDaySummary(for: row)
+                    return summary.costUSD != nil || summary.tokens != nil
+                }
+            monthlyUsesProviderSummary = summaryExtendsShortDashboardWindow
+                || providerCost > dailyCost
+                || providerTokens > dailyTokens
         }
 
         // Provider rows are computed from provider-level daily points. This
@@ -380,7 +434,10 @@ extension ShareCardData {
         self.providers = adjustedProviders.filter { $0.cost > 0 }
 
         // Top models (top 5 — bumped from 3 in iOS 1.9.0 for cap consistency).
-        self.topModels = modelRows(for: period)
+        self.topModels = modelRows(
+            for: period,
+            monthlyUsesProviderSummary: monthlyUsesProviderSummary,
+            monthlySummaryModelBreakdowns: monthlySummaryData.modelBreakdowns)
 
         // Daily bars
         let weekdayFormatter = DateFormatter()

--- a/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
@@ -151,6 +151,8 @@ extension ShareCardData {
     init(insights: CostDashboardInsights, period: SharePeriod) {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
+        let weekStart = calendar.date(byAdding: .day, value: -6, to: today)!
+        let monthStart = calendar.date(byAdding: .day, value: -29, to: today)!
 
         // Filter daily points by period
         let filteredDays: [CostDashboardInsights.DailyPoint]
@@ -158,10 +160,9 @@ extension ShareCardData {
         case .today:
             filteredDays = []
         case .week:
-            let weekStart = calendar.date(byAdding: .day, value: -6, to: today)!
             filteredDays = insights.dailyPoints.filter { $0.date >= weekStart }
         case .month:
-            filteredDays = insights.dailyPoints
+            filteredDays = insights.dailyPoints.filter { $0.date >= monthStart }
         }
 
         // Compute totals
@@ -177,8 +178,8 @@ extension ShareCardData {
             periodCost = filteredDays.reduce(0) { $0 + $1.costUSD }
             periodTokens = filteredDays.reduce(0) { $0 + $1.totalTokens }
         case .month:
-            periodCost = insights.total30DayCost
-            periodTokens = insights.total30DayTokens
+            periodCost = filteredDays.reduce(0) { $0 + $1.costUSD }
+            periodTokens = filteredDays.reduce(0) { $0 + $1.totalTokens }
         }
 
         // Provider rows are computed from provider-level daily points. This
@@ -189,12 +190,13 @@ extension ShareCardData {
             case .today:
                 cost = row.todayCost
             case .week:
-                let weekStart = calendar.date(byAdding: .day, value: -6, to: today)!
                 cost = row.dailyPoints
                     .filter { $0.date >= weekStart }
                     .reduce(0) { $0 + $1.costUSD }
             case .month:
-                cost = row.thirtyDayCost
+                cost = row.dailyPoints
+                    .filter { $0.date >= monthStart }
+                    .reduce(0) { $0 + $1.costUSD }
             }
             return ProviderRow(
                 name: row.provider.providerName,
@@ -208,7 +210,7 @@ extension ShareCardData {
         switch period {
         case .today: activeDays = 1
         case .week: activeDays = filteredDays.count(where: { $0.costUSD > 0 })
-        case .month: activeDays = insights.activeDayCount
+        case .month: activeDays = filteredDays.count(where: { $0.costUSD > 0 })
         }
 
         self.totalCost = periodCost

--- a/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
@@ -246,7 +246,10 @@ extension ShareCardData {
                     }
                 }
             }
-            if totals.isEmpty, period != .today {
+            let hasLedgerOnlyProvider = insights.providerRows.contains { row in
+                row.provider.costSummary == nil && (row.thirtyDayCost > 0 || !row.dailyPoints.isEmpty)
+            }
+            if period != .today && (totals.isEmpty || hasLedgerOnlyProvider) {
                 let fallbackRows = insights.modelRows
                     .filter { $0.amountUSD > 0 }
                     .sorted {

--- a/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
@@ -154,20 +154,21 @@ extension ShareCardData {
         let today = calendar.startOfDay(for: Date())
         let weekStart = calendar.date(byAdding: .day, value: -6, to: today)!
         let monthStart = calendar.date(byAdding: .day, value: -29, to: today)!
+        let tomorrow = calendar.date(byAdding: .day, value: 1, to: today)!
 
         // Filter daily points by period
         let filteredDays: [CostDashboardInsights.DailyPoint]
         switch period {
         case .today:
-            filteredDays = []
+            filteredDays = insights.dailyPoints.filter { calendar.isDate($0.date, inSameDayAs: today) }
         case .week:
-            filteredDays = insights.dailyPoints.filter { $0.date >= weekStart }
+            filteredDays = insights.dailyPoints.filter { $0.date >= weekStart && $0.date < tomorrow }
         case .month:
-            filteredDays = insights.dailyPoints.filter { $0.date >= monthStart }
+            filteredDays = insights.dailyPoints.filter { $0.date >= monthStart && $0.date < tomorrow }
         }
 
         func monthlyDailyPoints(for row: CostDashboardInsights.ProviderRow) -> [CostDashboardInsights.DailyPoint] {
-            row.dailyPoints.filter { $0.date >= monthStart }
+            row.dailyPoints.filter { $0.date >= monthStart && $0.date < tomorrow }
         }
 
         func authoritativeThirtyDaySummary(for row: CostDashboardInsights.ProviderRow) -> (costUSD: Double?, tokens: Int?) {
@@ -210,9 +211,9 @@ extension ShareCardData {
                 case .today:
                     return calendar.isDate(date, inSameDayAs: today)
                 case .week:
-                    return date >= weekStart
+                    return date >= weekStart && date < tomorrow
                 case .month:
-                    return date >= monthStart
+                    return date >= monthStart && date < tomorrow
                 }
             }
         }
@@ -256,17 +257,17 @@ extension ShareCardData {
 
         func modelRows(for period: SharePeriod) -> [BreakdownRow] {
             var totals: [String: Double] = [:]
-            for row in insights.providerRows {
-                for point in costSummaryPoints(for: row, period: period) {
-                    for breakdown in point.modelBreakdowns where breakdown.costUSD > 0 {
-                        totals[breakdown.label, default: 0] += breakdown.costUSD
-                    }
+            for point in filteredDays {
+                for breakdown in point.modelBreakdowns where breakdown.costUSD > 0 {
+                    totals[breakdown.label, default: 0] += breakdown.costUSD
                 }
             }
-            let hasLedgerOnlyProvider = insights.providerRows.contains { row in
-                row.provider.costSummary == nil && (row.thirtyDayCost > 0 || !row.dailyPoints.isEmpty)
+            let periodDays: Int = switch period {
+            case .today: 1
+            case .week: 7
+            case .month: 30
             }
-            if period != .today && (totals.isEmpty || hasLedgerOnlyProvider) {
+            if totals.isEmpty, (insights.historyDays ?? 30) <= periodDays {
                 let fallbackRows = insights.modelRows
                     .filter { $0.amountUSD > 0 }
                     .sorted {
@@ -342,7 +343,7 @@ extension ShareCardData {
                 cost = row.todayCost
             case .week:
                 cost = row.dailyPoints
-                    .filter { $0.date >= weekStart }
+                    .filter { $0.date >= weekStart && $0.date < tomorrow }
                     .reduce(0) { $0 + $1.costUSD }
             case .month:
                 cost = monthlyCost(for: row)

--- a/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
@@ -1,3 +1,4 @@
+import CodexBarSync
 import SwiftUI
 import CoreImage.CIFilterBuiltins
 
@@ -196,6 +197,55 @@ extension ShareCardData {
             return max(dailyTokens, summaryTokens)
         }
 
+        let dayKeyFormatter = SyncCostSummary.iso8601DayKeyFormatter()
+
+        func costSummaryPoints(
+            for row: CostDashboardInsights.ProviderRow,
+            period: SharePeriod
+        ) -> [SyncDailyPoint] {
+            guard let summary = row.provider.costSummary else { return [] }
+            return summary.daily.filter { point in
+                guard let date = dayKeyFormatter.date(from: point.dayKey) else { return false }
+                switch period {
+                case .today:
+                    return calendar.isDate(date, inSameDayAs: today)
+                case .week:
+                    return date >= weekStart
+                case .month:
+                    return date >= monthStart
+                }
+            }
+        }
+
+        func modelRows(for period: SharePeriod) -> [BreakdownRow] {
+            var totals: [String: Double] = [:]
+            for row in insights.providerRows {
+                for point in costSummaryPoints(for: row, period: period) {
+                    for breakdown in point.modelBreakdowns where breakdown.costUSD > 0 {
+                        totals[breakdown.label, default: 0] += breakdown.costUSD
+                    }
+                }
+            }
+            let totalModel = totals.values.reduce(0, +)
+            guard totalModel > 0 else { return [] }
+            return totals
+                .map { label, cost in
+                    BreakdownRow(
+                        label: label,
+                        cost: cost,
+                        share: cost / totalModel)
+                }
+                .sorted {
+                    if $0.cost == $1.cost {
+                        $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending
+                    } else {
+                        $0.cost > $1.cost
+                    }
+                }
+                .prefix(5)
+                .map { $0 }
+        }
+
         // Compute totals
         let periodCost: Double
         let periodTokens: Int
@@ -254,14 +304,7 @@ extension ShareCardData {
         self.providers = adjustedProviders.filter { $0.cost > 0 }
 
         // Top models (top 5 — bumped from 3 in iOS 1.9.0 for cap consistency).
-        self.topModels = insights.modelRows.prefix(5).map { row in
-            let totalModel = insights.modelRows.reduce(0.0) { $0 + $1.amountUSD }
-            return BreakdownRow(
-                label: row.label,
-                cost: row.amountUSD,
-                share: totalModel > 0 ? row.amountUSD / totalModel : 0
-            )
-        }
+        self.topModels = modelRows(for: period)
 
         // Daily bars
         let weekdayFormatter = DateFormatter()

--- a/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
@@ -219,11 +219,28 @@ extension ShareCardData {
 
         func monthlySummaryDailyPoints() -> [CostDashboardInsights.DailyPoint] {
             var totals: [String: (date: Date, costUSD: Double, totalTokens: Int)] = [:]
+            func addDay(dayKey: String, date: Date, costUSD: Double, totalTokens: Int) {
+                totals[dayKey, default: (date, 0, 0)].costUSD += costUSD
+                totals[dayKey, default: (date, 0, 0)].totalTokens += totalTokens
+            }
             for row in insights.providerRows {
-                for point in costSummaryPoints(for: row, period: .month) {
-                    guard let date = dayKeyFormatter.date(from: point.dayKey) else { continue }
-                    totals[point.dayKey, default: (date, 0, 0)].costUSD += point.costUSD
-                    totals[point.dayKey, default: (date, 0, 0)].totalTokens += point.totalTokens
+                if row.provider.costSummary == nil {
+                    for point in monthlyDailyPoints(for: row) {
+                        addDay(
+                            dayKey: point.dayKey,
+                            date: point.date,
+                            costUSD: point.costUSD,
+                            totalTokens: point.totalTokens)
+                    }
+                } else {
+                    for point in costSummaryPoints(for: row, period: .month) {
+                        guard let date = dayKeyFormatter.date(from: point.dayKey) else { continue }
+                        addDay(
+                            dayKey: point.dayKey,
+                            date: date,
+                            costUSD: point.costUSD,
+                            totalTokens: point.totalTokens)
+                    }
                 }
             }
             return totals

--- a/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
@@ -165,6 +165,37 @@ extension ShareCardData {
             filteredDays = insights.dailyPoints.filter { $0.date >= monthStart }
         }
 
+        func monthlyDailyPoints(for row: CostDashboardInsights.ProviderRow) -> [CostDashboardInsights.DailyPoint] {
+            row.dailyPoints.filter { $0.date >= monthStart }
+        }
+
+        func authoritativeThirtyDaySummary(for row: CostDashboardInsights.ProviderRow) -> (costUSD: Double?, tokens: Int?) {
+            guard let summary = row.provider.costSummary else {
+                return (nil, nil)
+            }
+            let summaryWindowDays = max(1, min(summary.historyDays ?? 30, 365))
+            guard summaryWindowDays <= 30 else {
+                return (nil, nil)
+            }
+            return (summary.last30DaysCostUSD, summary.last30DaysTokens)
+        }
+
+        func monthlyCost(for row: CostDashboardInsights.ProviderRow) -> Double {
+            let dailyCost = monthlyDailyPoints(for: row).reduce(0) { $0 + $1.costUSD }
+            guard let summaryCost = authoritativeThirtyDaySummary(for: row).costUSD else {
+                return dailyCost
+            }
+            return max(dailyCost, summaryCost)
+        }
+
+        func monthlyTokens(for row: CostDashboardInsights.ProviderRow) -> Int {
+            let dailyTokens = monthlyDailyPoints(for: row).reduce(0) { $0 + $1.totalTokens }
+            guard let summaryTokens = authoritativeThirtyDaySummary(for: row).tokens else {
+                return dailyTokens
+            }
+            return max(dailyTokens, summaryTokens)
+        }
+
         // Compute totals
         let periodCost: Double
         let periodTokens: Int
@@ -178,8 +209,12 @@ extension ShareCardData {
             periodCost = filteredDays.reduce(0) { $0 + $1.costUSD }
             periodTokens = filteredDays.reduce(0) { $0 + $1.totalTokens }
         case .month:
-            periodCost = filteredDays.reduce(0) { $0 + $1.costUSD }
-            periodTokens = filteredDays.reduce(0) { $0 + $1.totalTokens }
+            let providerCost = insights.providerRows.reduce(0) { $0 + monthlyCost(for: $1) }
+            let dailyCost = filteredDays.reduce(0) { $0 + $1.costUSD }
+            periodCost = providerCost > 0 ? providerCost : dailyCost
+            let providerTokens = insights.providerRows.reduce(0) { $0 + monthlyTokens(for: $1) }
+            let dailyTokens = filteredDays.reduce(0) { $0 + $1.totalTokens }
+            periodTokens = providerTokens > 0 ? providerTokens : dailyTokens
         }
 
         // Provider rows are computed from provider-level daily points. This
@@ -194,9 +229,7 @@ extension ShareCardData {
                     .filter { $0.date >= weekStart }
                     .reduce(0) { $0 + $1.costUSD }
             case .month:
-                cost = row.dailyPoints
-                    .filter { $0.date >= monthStart }
-                    .reduce(0) { $0 + $1.costUSD }
+                cost = monthlyCost(for: row)
             }
             return ProviderRow(
                 name: row.provider.providerName,

--- a/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
@@ -246,6 +246,27 @@ extension ShareCardData {
                     }
                 }
             }
+            if totals.isEmpty, period != .today {
+                let fallbackRows = insights.modelRows
+                    .filter { $0.amountUSD > 0 }
+                    .sorted {
+                        if $0.amountUSD == $1.amountUSD {
+                            $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending
+                        } else {
+                            $0.amountUSD > $1.amountUSD
+                        }
+                    }
+                    .prefix(5)
+                let fallbackTotal = fallbackRows.reduce(0) { $0 + $1.amountUSD }
+                guard fallbackTotal > 0 else { return [] }
+                return fallbackRows
+                    .map { row in
+                        BreakdownRow(
+                            label: row.label,
+                            cost: row.amountUSD,
+                            share: row.amountUSD / fallbackTotal)
+                    }
+            }
             let totalModel = totals.values.reduce(0, +)
             guard totalModel > 0 else { return [] }
             return totals

--- a/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/CostShareService.swift
@@ -217,6 +217,26 @@ extension ShareCardData {
             }
         }
 
+        func monthlySummaryDailyPoints() -> [CostDashboardInsights.DailyPoint] {
+            var totals: [String: (date: Date, costUSD: Double, totalTokens: Int)] = [:]
+            for row in insights.providerRows {
+                for point in costSummaryPoints(for: row, period: .month) {
+                    guard let date = dayKeyFormatter.date(from: point.dayKey) else { continue }
+                    totals[point.dayKey, default: (date, 0, 0)].costUSD += point.costUSD
+                    totals[point.dayKey, default: (date, 0, 0)].totalTokens += point.totalTokens
+                }
+            }
+            return totals
+                .map { dayKey, total in
+                    CostDashboardInsights.DailyPoint(
+                        dayKey: dayKey,
+                        date: total.date,
+                        costUSD: total.costUSD,
+                        totalTokens: total.totalTokens)
+                }
+                .sorted { $0.date < $1.date }
+        }
+
         func modelRows(for period: SharePeriod) -> [BreakdownRow] {
             var totals: [String: Double] = [:]
             for row in insights.providerRows {
@@ -249,15 +269,19 @@ extension ShareCardData {
         // Compute totals
         let periodCost: Double
         let periodTokens: Int
+        let monthlySummaryDays = monthlySummaryDailyPoints()
+        let monthlyUsesProviderSummary: Bool
         switch period {
         case .today:
             periodCost = insights.totalTodayCost
             periodTokens = insights.providerRows.reduce(0) { total, row in
                 total + row.todayTokens
             }
+            monthlyUsesProviderSummary = false
         case .week:
             periodCost = filteredDays.reduce(0) { $0 + $1.costUSD }
             periodTokens = filteredDays.reduce(0) { $0 + $1.totalTokens }
+            monthlyUsesProviderSummary = false
         case .month:
             let providerCost = insights.providerRows.reduce(0) { $0 + monthlyCost(for: $1) }
             let dailyCost = filteredDays.reduce(0) { $0 + $1.costUSD }
@@ -265,6 +289,7 @@ extension ShareCardData {
             let providerTokens = insights.providerRows.reduce(0) { $0 + monthlyTokens(for: $1) }
             let dailyTokens = filteredDays.reduce(0) { $0 + $1.totalTokens }
             periodTokens = providerTokens > 0 ? providerTokens : dailyTokens
+            monthlyUsesProviderSummary = providerCost > dailyCost || providerTokens > dailyTokens
         }
 
         // Provider rows are computed from provider-level daily points. This
@@ -290,10 +315,19 @@ extension ShareCardData {
         }
 
         let activeDays: Int
+        let displayDays: [CostDashboardInsights.DailyPoint]
         switch period {
-        case .today: activeDays = 1
-        case .week: activeDays = filteredDays.count(where: { $0.costUSD > 0 })
-        case .month: activeDays = filteredDays.count(where: { $0.costUSD > 0 })
+        case .today:
+            displayDays = []
+            activeDays = 1
+        case .week:
+            displayDays = filteredDays
+            activeDays = displayDays.count(where: { $0.costUSD > 0 })
+        case .month:
+            displayDays = monthlyUsesProviderSummary && !monthlySummaryDays.isEmpty
+                ? monthlySummaryDays
+                : filteredDays
+            activeDays = displayDays.count(where: { $0.costUSD > 0 })
         }
 
         self.totalCost = periodCost
@@ -314,11 +348,11 @@ extension ShareCardData {
         case .today:
             self.dailyBars = []
         case .week:
-            self.dailyBars = filteredDays.map { point in
+            self.dailyBars = displayDays.map { point in
                 DailyBar(label: weekdayFormatter.string(from: point.date), cost: point.costUSD)
             }
         case .month:
-            self.dailyBars = filteredDays.enumerated().map { index, point in
+            self.dailyBars = displayDays.enumerated().map { index, point in
                 let dayNum = index + 1
                 // Label every 7th day (= one label per week) plus day 1 and
                 // the final day for visual anchors. On a 30-day window this
@@ -327,7 +361,7 @@ extension ShareCardData {
                 // count: 7)` gridlines, so the share card and dashboard
                 // chart read as a matching pair. Changing the 7 here will
                 // un-sync the two charts — also update ContentView's stride.
-                let showLabel = dayNum == 1 || dayNum % 7 == 0 || dayNum == filteredDays.count
+                let showLabel = dayNum == 1 || dayNum % 7 == 0 || dayNum == displayDays.count
                 return DailyBar(label: showLabel ? "\(dayNum)" : "", cost: point.costUSD)
             }
         }

--- a/CodexBarMobile/CodexBarMobile/Models/MobileDisplayPreferences.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/MobileDisplayPreferences.swift
@@ -31,6 +31,10 @@ enum MobileSettingsKeys {
     /// is on, aggregates the ledger over this trailing window. Picker offers
     /// 7 / 30 / 90 / 365; default 90.
     static let cwlWindowDays = "cwlWindowDays"
+    /// Timestamp written when the user explicitly clears local cost history.
+    /// Default-on blob migration only seeds provider blobs newer than this
+    /// value, so a normal Cost-page read cannot immediately undo the clear.
+    static let cwlBlobSeedClearedAt = "cwlBlobSeedClearedAt"
 }
 
 enum MobileSettingsDefaults {

--- a/CodexBarMobile/CodexBarMobile/Models/MobileDisplayPreferences.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/MobileDisplayPreferences.swift
@@ -22,16 +22,20 @@ enum MobileSettingsKeys {
     // iOS 1.9.0 + Round 2 (research doc 024) — Cost Window Ledger.
     /// When `true`, `SwiftDataBridge.upsertProvider` also writes each
     /// per-day cost point into the `DailyCostPoint` ledger (via
-    /// `CostLedgerService.upsertFromSnapshot`). When `false` (default), the
-    /// ledger is untouched — every existing user keeps exactly build-140
-    /// behavior. UI to flip this lands in Round 4 / P4. Reader (Round 3 /
-    /// P3) honors the same key when deciding whether to read from the
-    /// ledger vs. the existing blob path.
+    /// `CostLedgerService.upsertFromSnapshot`). Defaults to `true` so Cost
+    /// uses the local daily ledger when available, with the existing blob path
+    /// as fallback. Reader (Round 3 / P3) honors the same key when deciding
+    /// whether to read from the ledger vs. the existing blob path.
     static let cwlEnabled = "cwlEnabled"
     /// CWL cost window in days (Round 6 / P4b). The Cost dashboard, when CWL
     /// is on, aggregates the ledger over this trailing window. Picker offers
-    /// 7 / 30 / 90 / 365; default 30 (matches the historical blob window).
+    /// 7 / 30 / 90 / 365; default 90.
     static let cwlWindowDays = "cwlWindowDays"
+}
+
+enum MobileSettingsDefaults {
+    static let cwlEnabled = true
+    static let cwlWindowDays = 90
 }
 
 enum UsagePercentDisplayMode: String, CaseIterable, Identifiable {

--- a/CodexBarMobile/CodexBarMobile/Models/SyncedUsageData.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/SyncedUsageData.swift
@@ -664,15 +664,18 @@ final class SyncedUsageData {
             }
         }
 
-        // 5. Republish merged view.
-        self.republishFromCache()
+        // 5. Mirror the incrementally refreshed cache to SwiftData, then
+        // republish the merged view. The Cost ledger reads SwiftData by
+        // default, so incremental sync must keep it in lockstep with the
+        // in-memory snapshot cache.
+        self.republishFromCache(persistToSwiftData: context)
     }
 
     // MARK: - Republish helper
 
     /// Derive the published state from the current cache. Called after every
     /// mutation (full fetch, incremental delta, cold-start seed).
-    private func republishFromCache() {
+    private func republishFromCache(persistToSwiftData context: ModelContext? = nil) {
         let rawDeviceSnapshots = self.cache.buildDeviceSnapshots()
         self.rawDeviceSnapshots = rawDeviceSnapshots
         let resolution = CloudSyncReader.resolveDeviceSnapshots(
@@ -681,6 +684,16 @@ final class SyncedUsageData {
             providerLinkages: self.providerLinkages)
         self.deviceSnapshots = resolution.activeSnapshots
         self.deviceManagementItems = resolution.items
+
+        let merged = CloudSyncReader.mergeSnapshots(
+            resolution.activeSnapshots,
+            linkages: self.providerLinkages)
+        if let context {
+            CloudSyncReader.persistToSwiftData(
+                deviceSnapshots: rawDeviceSnapshots,
+                merged: merged,
+                context: context)
+        }
 
         if rawDeviceSnapshots.isEmpty {
             self.snapshot = nil
@@ -692,9 +705,7 @@ final class SyncedUsageData {
             }
             return
         }
-        if let merged = CloudSyncReader.mergeSnapshots(
-            resolution.activeSnapshots, linkages: self.providerLinkages)
-        {
+        if let merged {
             self.snapshot = merged
             self.syncStatus = .synced(ago: Date().timeIntervalSince(merged.syncTimestamp))
         } else if resolution.activeSnapshots.isEmpty {

--- a/CodexBarMobile/CodexBarMobile/Models/SyncedUsageData.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/SyncedUsageData.swift
@@ -668,14 +668,17 @@ final class SyncedUsageData {
         // republish the merged view. The Cost ledger reads SwiftData by
         // default, so incremental sync must keep it in lockstep with the
         // in-memory snapshot cache.
-        self.republishFromCache(persistToSwiftData: context)
+        self.republishFromCache(persistIncrementallyToSwiftData: context)
     }
 
     // MARK: - Republish helper
 
     /// Derive the published state from the current cache. Called after every
     /// mutation (full fetch, incremental delta, cold-start seed).
-    private func republishFromCache(persistToSwiftData context: ModelContext? = nil) {
+    private func republishFromCache(
+        persistToSwiftData context: ModelContext? = nil,
+        persistIncrementallyToSwiftData incrementalContext: ModelContext? = nil)
+    {
         let rawDeviceSnapshots = self.cache.buildDeviceSnapshots()
         self.rawDeviceSnapshots = rawDeviceSnapshots
         let resolution = CloudSyncReader.resolveDeviceSnapshots(
@@ -693,6 +696,11 @@ final class SyncedUsageData {
                 deviceSnapshots: rawDeviceSnapshots,
                 merged: merged,
                 context: context)
+        }
+        if let incrementalContext {
+            CloudSyncReader.persistIncrementalToSwiftData(
+                deviceSnapshots: rawDeviceSnapshots,
+                context: incrementalContext)
         }
 
         if rawDeviceSnapshots.isEmpty {

--- a/CodexBarMobile/CodexBarMobile/Models/SyncedUsageData.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/SyncedUsageData.swift
@@ -707,8 +707,8 @@ final class SyncedUsageData {
                 context: context)
         }
         if let incrementalContext {
-            CloudSyncReader.persistIncrementalToSwiftData(
-                deviceSnapshots: Self.snapshotsFilteringDeletedProvidersForIncrementalPersistence(
+            CloudSyncReader.persistIncrementalCacheMirrorToSwiftData(
+                cacheDeviceSnapshots: Self.snapshotsFilteringDeletedProvidersForIncrementalPersistence(
                     rawDeviceSnapshots,
                     deletedRecordNames: deletedRecordNames),
                 deletedRecordNames: deletedRecordNames,

--- a/CodexBarMobile/CodexBarMobile/Models/SyncedUsageData.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/SyncedUsageData.swift
@@ -609,12 +609,14 @@ final class SyncedUsageData {
         //    nil-token reply replays every record currently in the zone, so
         //    we treat it as a FULL replacement of the per-provider bucket
         //    (equivalent to a full fetch of the new zone).
+        var didReplayProviderZoneReplacement = false
         if delta.tokenExpired {
             try? SwiftDataBridge.saveChangeToken(
                 forZone: zoneName, tokenData: nil, context: context)
             delta = await reader.fetchPerProviderZoneChanges(since: nil)
             if !delta.tokenExpired, !delta.zoneMissing {
                 self.cache.replacePerProviderFromReplay(delta.upserted)
+                didReplayProviderZoneReplacement = true
             }
         } else if delta.zoneMissing {
             // No zone yet — nothing to apply. The priority merge will fall
@@ -668,9 +670,13 @@ final class SyncedUsageData {
         // republish the merged view. The Cost ledger reads SwiftData by
         // default, so incremental sync must keep it in lockstep with the
         // in-memory snapshot cache.
-        self.republishFromCache(
-            persistIncrementallyToSwiftData: context,
-            deletedRecordNames: delta.deletedRecordNames)
+        if didReplayProviderZoneReplacement {
+            self.republishFromCache(persistToSwiftData: context)
+        } else {
+            self.republishFromCache(
+                persistIncrementallyToSwiftData: context,
+                deletedRecordNames: delta.deletedRecordNames)
+        }
     }
 
     // MARK: - Republish helper

--- a/CodexBarMobile/CodexBarMobile/Models/SyncedUsageData.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/SyncedUsageData.swift
@@ -708,7 +708,9 @@ final class SyncedUsageData {
         }
         if let incrementalContext {
             CloudSyncReader.persistIncrementalToSwiftData(
-                deviceSnapshots: rawDeviceSnapshots,
+                deviceSnapshots: Self.snapshotsFilteringDeletedProvidersForIncrementalPersistence(
+                    rawDeviceSnapshots,
+                    deletedRecordNames: deletedRecordNames),
                 deletedRecordNames: deletedRecordNames,
                 context: incrementalContext)
         }
@@ -733,6 +735,52 @@ final class SyncedUsageData {
         } else {
             self.syncStatus = .incompatibleData
         }
+    }
+
+    nonisolated static func snapshotsFilteringDeletedProvidersForIncrementalPersistence(
+        _ snapshots: [SyncedUsageSnapshot],
+        deletedRecordNames: [String]
+    ) -> [SyncedUsageSnapshot] {
+        var deletedByDevice: [String: Set<String>] = [:]
+        for recordName in deletedRecordNames {
+            guard let parsed = Self.splitProviderRecordName(recordName) else { continue }
+            deletedByDevice[parsed.deviceID, default: []].insert(parsed.composite)
+        }
+        guard !deletedByDevice.isEmpty else { return snapshots }
+
+        return snapshots.map { snapshot in
+            guard let deviceID = snapshot.deviceID,
+                  let deletedComposites = deletedByDevice[deviceID],
+                  !deletedComposites.isEmpty
+            else {
+                return snapshot
+            }
+            let providers = snapshot.providers.filter { provider in
+                !deletedComposites.contains(Self.providerCompositeKey(provider))
+            }
+            guard providers.count != snapshot.providers.count else { return snapshot }
+            return SyncedUsageSnapshot(
+                providers: providers,
+                syncTimestamp: snapshot.syncTimestamp,
+                deviceName: snapshot.deviceName,
+                deviceID: snapshot.deviceID,
+                appVersion: snapshot.appVersion,
+                mobileVersion: snapshot.mobileVersion,
+                notificationPushEnabled: snapshot.notificationPushEnabled)
+        }
+    }
+
+    private nonisolated static func splitProviderRecordName(_ recordName: String) -> (
+        deviceID: String,
+        composite: String
+    )? {
+        let parts = recordName.split(separator: "|", omittingEmptySubsequences: false)
+        guard parts.count == 3 else { return nil }
+        return (String(parts[0]), "\(parts[1])|\(parts[2])")
+    }
+
+    private nonisolated static func providerCompositeKey(_ provider: ProviderUsageSnapshot) -> String {
+        "\(provider.providerID)|\(provider.accountEmail ?? "_")"
     }
 
     // MARK: - Public API

--- a/CodexBarMobile/CodexBarMobile/Models/SyncedUsageData.swift
+++ b/CodexBarMobile/CodexBarMobile/Models/SyncedUsageData.swift
@@ -668,7 +668,9 @@ final class SyncedUsageData {
         // republish the merged view. The Cost ledger reads SwiftData by
         // default, so incremental sync must keep it in lockstep with the
         // in-memory snapshot cache.
-        self.republishFromCache(persistIncrementallyToSwiftData: context)
+        self.republishFromCache(
+            persistIncrementallyToSwiftData: context,
+            deletedRecordNames: delta.deletedRecordNames)
     }
 
     // MARK: - Republish helper
@@ -677,7 +679,8 @@ final class SyncedUsageData {
     /// mutation (full fetch, incremental delta, cold-start seed).
     private func republishFromCache(
         persistToSwiftData context: ModelContext? = nil,
-        persistIncrementallyToSwiftData incrementalContext: ModelContext? = nil)
+        persistIncrementallyToSwiftData incrementalContext: ModelContext? = nil,
+        deletedRecordNames: [String] = [])
     {
         let rawDeviceSnapshots = self.cache.buildDeviceSnapshots()
         self.rawDeviceSnapshots = rawDeviceSnapshots
@@ -700,6 +703,7 @@ final class SyncedUsageData {
         if let incrementalContext {
             CloudSyncReader.persistIncrementalToSwiftData(
                 deviceSnapshots: rawDeviceSnapshots,
+                deletedRecordNames: deletedRecordNames,
                 context: incrementalContext)
         }
 

--- a/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
@@ -349,9 +349,10 @@ enum CostLedgerService {
             serviceMix: serviceMix)
     }
 
-    /// Aggregate for default-on CWL readers. If the ledger is still empty but
-    /// existing synced blob snapshots are present, seed those blobs first and
-    /// re-run the aggregate so upgraded users do not briefly lose Cost history.
+    /// Aggregate for default-on CWL readers. If existing synced blob snapshots
+    /// contain rows not yet represented in the ledger, seed those missing rows
+    /// first and re-run the aggregate so upgraded or partially seeded users do
+    /// not lose Daily Spend / Model Mix / Service Mix history.
     static func aggregateSeedingFromExistingBlobsIfNeeded(
         windowDays: Int,
         in context: ModelContext,
@@ -359,19 +360,10 @@ enum CostLedgerService {
         activeDeviceIDs: Set<String>? = nil,
         userDefaults: UserDefaults = .standard) throws -> CostLedgerAggregation
     {
-        let first = try Self.aggregate(
-            windowDays: windowDays,
-            in: context,
-            asOf: asOf,
-            activeDeviceIDs: activeDeviceIDs)
         let clearedAt = Self.blobSeedClearedAt(userDefaults: userDefaults)
-        guard !first.hasDisplayData,
-              try Self.hasSeedableCostBlobs(in: context, newerThan: clearedAt)
-        else {
-            return first
+        if try Self.hasMissingSeedableCostBlobRows(in: context, newerThan: clearedAt) {
+            try Self.seedFromExistingBlobs(in: context, newerThan: clearedAt)
         }
-
-        try Self.seedFromExistingBlobs(in: context, newerThan: clearedAt)
         return try Self.aggregate(
             windowDays: windowDays,
             in: context,
@@ -505,14 +497,30 @@ enum CostLedgerService {
             newerThan: Self.blobSeedClearedAt(userDefaults: userDefaults))
     }
 
-    private static func hasSeedableCostBlobs(in context: ModelContext, newerThan: Date?) throws -> Bool {
-        try context.fetch(FetchDescriptor<ProviderSnapshotModel>()).contains { row in
-            guard row.costSummaryData != nil else { return false }
-            if let newerThan {
-                return row.lastUpdated > newerThan
+    private static func hasMissingSeedableCostBlobRows(in context: ModelContext, newerThan: Date?) throws -> Bool {
+        let providers = try context.fetch(FetchDescriptor<ProviderSnapshotModel>())
+        let decoder = CloudSyncConstants.makeJSONDecoder()
+        for row in providers {
+            if let newerThan, row.lastUpdated <= newerThan { continue }
+            guard let blob = row.costSummaryData,
+                  let summary = try? decoder.decode(SyncCostSummary.self, from: blob)
+            else { continue }
+            for point in summary.daily {
+                let key = DailyCostPoint.makeCompositeKey(
+                    deviceID: row.deviceID,
+                    providerID: row.providerID,
+                    accountEmail: row.accountEmail,
+                    dayKey: point.dayKey)
+                let descriptor = FetchDescriptor<DailyCostPoint>(
+                    predicate: #Predicate { $0.compositeKey == key })
+                guard let existing = try context.fetch(descriptor).first,
+                      existing.lastUpdated >= row.lastUpdated
+                else {
+                    return true
+                }
             }
-            return true
         }
+        return false
     }
 
     private static func blobSeedClearedAt(userDefaults: UserDefaults) -> Date? {

--- a/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
@@ -493,6 +493,18 @@ enum CostLedgerService {
         try context.save()
     }
 
+    /// Seed existing blob-path history while preserving an explicit clear
+    /// boundary. Used by the Settings off→on path so re-enabling Local Cost
+    /// History does not restore blob data the user just cleared.
+    static func seedFromExistingBlobsRespectingClearTombstone(
+        in context: ModelContext,
+        userDefaults: UserDefaults = .standard) throws
+    {
+        try Self.seedFromExistingBlobs(
+            in: context,
+            newerThan: Self.blobSeedClearedAt(userDefaults: userDefaults))
+    }
+
     private static func hasSeedableCostBlobs(in context: ModelContext, newerThan: Date?) throws -> Bool {
         try context.fetch(FetchDescriptor<ProviderSnapshotModel>()).contains { row in
             guard row.costSummaryData != nil else { return false }

--- a/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
@@ -445,6 +445,27 @@ enum CostLedgerService {
             forKey: MobileSettingsKeys.cwlBlobSeedClearedAt)
     }
 
+    static func deleteRows(
+        deviceID: String,
+        providerID: String,
+        accountEmail: String?,
+        in context: ModelContext
+    ) throws {
+        let descriptor = FetchDescriptor<DailyCostPoint>(
+            predicate: #Predicate {
+                $0.deviceID == deviceID && $0.providerID == providerID
+            })
+        let rows = try context.fetch(descriptor)
+        var didDelete = false
+        for row in rows where row.accountEmail == accountEmail {
+            context.delete(row)
+            didDelete = true
+        }
+        if didDelete {
+            try context.save()
+        }
+    }
+
     // MARK: - Seed from existing blobs (migration · Round 7 / P6)
 
     /// One-shot import of the existing blob-path data into the ledger. Run on

--- a/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
@@ -360,6 +360,8 @@ enum CostLedgerService {
         activeDeviceIDs: Set<String>? = nil,
         userDefaults: UserDefaults = .standard) throws -> CostLedgerAggregation
     {
+        try Self.pruneLedgerRowsMissingProviderSnapshots(in: context)
+
         let clearedAt = Self.blobSeedClearedAt(userDefaults: userDefaults)
         if try Self.hasMissingSeedableCostBlobRows(in: context, newerThan: clearedAt) {
             try Self.seedFromExistingBlobs(in: context, newerThan: clearedAt)
@@ -521,6 +523,29 @@ enum CostLedgerService {
             }
         }
         return false
+    }
+
+    private static func pruneLedgerRowsMissingProviderSnapshots(in context: ModelContext) throws {
+        let providerKeys = Set(
+            try context.fetch(FetchDescriptor<ProviderSnapshotModel>())
+                .map(\.compositeKey))
+        guard !providerKeys.isEmpty else { return }
+
+        let rows = try context.fetch(FetchDescriptor<DailyCostPoint>())
+        var didDelete = false
+        for row in rows {
+            let providerKey = ProviderSnapshotModel.makeCompositeKey(
+                deviceID: row.deviceID,
+                providerID: row.providerID,
+                accountEmail: row.accountEmail)
+            if !providerKeys.contains(providerKey) {
+                context.delete(row)
+                didDelete = true
+            }
+        }
+        if didDelete {
+            try context.save()
+        }
     }
 
     private static func blobSeedClearedAt(userDefaults: UserDefaults) -> Date? {

--- a/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
@@ -348,20 +348,22 @@ enum CostLedgerService {
         windowDays: Int,
         in context: ModelContext,
         asOf: Date = Date(),
-        activeDeviceIDs: Set<String>? = nil) throws -> CostLedgerAggregation
+        activeDeviceIDs: Set<String>? = nil,
+        userDefaults: UserDefaults = .standard) throws -> CostLedgerAggregation
     {
         let first = try Self.aggregate(
             windowDays: windowDays,
             in: context,
             asOf: asOf,
             activeDeviceIDs: activeDeviceIDs)
+        let clearedAt = Self.blobSeedClearedAt(userDefaults: userDefaults)
         guard !first.hasDisplayData,
-              try Self.hasSeedableCostBlobs(in: context)
+              try Self.hasSeedableCostBlobs(in: context, newerThan: clearedAt)
         else {
             return first
         }
 
-        try Self.seedFromExistingBlobs(in: context)
+        try Self.seedFromExistingBlobs(in: context, newerThan: clearedAt)
         return try Self.aggregate(
             windowDays: windowDays,
             in: context,
@@ -427,11 +429,18 @@ enum CostLedgerService {
     /// Delete every `DailyCostPoint` row. Wired to the Settings "clear ledger"
     /// button (with a confirmation dialog). Touches ONLY the ledger — the blob
     /// path (`ProviderSnapshotModel.costSummaryData`) and all other SwiftData
-    /// entities are untouched, so toggling CWL off + clearing leaves the
-    /// build-140 dashboard fully intact.
-    static func clearAll(in context: ModelContext) throws {
+    /// entities are untouched. A clear timestamp is written so the default-on
+    /// migration path cannot immediately rebuild the ledger from older blobs.
+    static func clearAll(
+        in context: ModelContext,
+        clearedAt: Date = Date(),
+        userDefaults: UserDefaults = .standard) throws
+    {
         try context.delete(model: DailyCostPoint.self)
         try context.save()
+        userDefaults.set(
+            clearedAt.timeIntervalSince1970,
+            forKey: MobileSettingsKeys.cwlBlobSeedClearedAt)
     }
 
     // MARK: - Seed from existing blobs (migration · Round 7 / P6)
@@ -448,11 +457,12 @@ enum CostLedgerService {
     /// no-op. A corrupt / undecodable blob is skipped (that provider just has
     /// no seeded history); other rows still seed. Throws only on the final
     /// `save()` — the caller (toggle-on) turns CWL back off on throw.
-    static func seedFromExistingBlobs(in context: ModelContext) throws {
+    static func seedFromExistingBlobs(in context: ModelContext, newerThan: Date? = nil) throws {
         let providers = try context.fetch(FetchDescriptor<ProviderSnapshotModel>())
         let decoder = CloudSyncConstants.makeJSONDecoder()
         let encoder = CloudSyncConstants.makeJSONEncoder()
         for row in providers {
+            if let newerThan, row.lastUpdated <= newerThan { continue }
             guard let blob = row.costSummaryData,
                   let summary = try? decoder.decode(SyncCostSummary.self, from: blob)
             else { continue }
@@ -475,10 +485,23 @@ enum CostLedgerService {
         try context.save()
     }
 
-    private static func hasSeedableCostBlobs(in context: ModelContext) throws -> Bool {
-        let descriptor = FetchDescriptor<ProviderSnapshotModel>(
-            predicate: #Predicate { $0.costSummaryData != nil })
-        return !(try context.fetch(descriptor)).isEmpty
+    private static func hasSeedableCostBlobs(in context: ModelContext, newerThan: Date?) throws -> Bool {
+        try context.fetch(FetchDescriptor<ProviderSnapshotModel>()).contains { row in
+            guard row.costSummaryData != nil else { return false }
+            if let newerThan {
+                return row.lastUpdated > newerThan
+            }
+            return true
+        }
+    }
+
+    private static func blobSeedClearedAt(userDefaults: UserDefaults) -> Date? {
+        guard let rawValue = userDefaults.object(forKey: MobileSettingsKeys.cwlBlobSeedClearedAt) as? Double,
+              rawValue > 0
+        else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: rawValue)
     }
 
     // MARK: - Helpers

--- a/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
@@ -99,9 +99,9 @@ struct CostLedgerDiagnostics: Equatable {
 
 enum CostLedgerService {
 
-    /// `YYYY-MM-DD` UTC formatter, matches the wire format's `SyncDailyPoint.dayKey`.
-    /// Static so we don't reallocate per call; `DateFormatter` is reentrant-safe
-    /// for read-only use after configuration.
+    /// `YYYY-MM-DD` UTC formatter retained for deterministic historical test
+    /// fixtures. Production window cutoffs use `SyncCostSummary`'s local
+    /// day-key formatter so CWL windows match Mac-synced cost day keys.
     static let utcDayKeyFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "yyyy-MM-dd"
@@ -247,7 +247,7 @@ enum CostLedgerService {
     ///   account / day because those APIs already return account-wide totals.
     ///
     /// `asOf` exists for deterministic tests; production callers pass `Date()`.
-    /// The "window" is `[asOf-(windowDays-1) … asOf]` in UTC dayKeys.
+    /// The "window" is `[asOf-(windowDays-1) … asOf]` in local dayKeys.
     ///
     /// O(n) over surviving rows after window filter. For Round 7 / P7
     /// performance work we may move this to a background actor; for now
@@ -588,16 +588,17 @@ enum CostLedgerService {
     // MARK: - Helpers
 
     /// `[asOf - (windowDays - 1) days, asOf]` lower bound as a `YYYY-MM-DD`
-    /// UTC dayKey string. Comparison against `DailyCostPoint.dayKey` works
+    /// local dayKey string. Comparison against `DailyCostPoint.dayKey` works
     /// lexicographically because the format is fixed-width.
     static func cutoffDayKey(windowDays: Int, asOf: Date) -> String {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(identifier: "UTC") ?? .gmt
+        calendar.timeZone = .current
+        let localDay = calendar.startOfDay(for: asOf)
         let cutoff = calendar.date(
             byAdding: .day,
             value: -(windowDays - 1),
-            to: asOf) ?? asOf
-        return Self.utcDayKeyFormatter.string(from: cutoff)
+            to: localDay) ?? localDay
+        return SyncCostSummary.iso8601DayKeyFormatter().string(from: cutoff)
     }
 
     // MARK: - Private accumulators

--- a/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
@@ -445,6 +445,10 @@ enum CostLedgerService {
             forKey: MobileSettingsKeys.cwlBlobSeedClearedAt)
     }
 
+    static func hasBlobSeedClearTombstone(userDefaults: UserDefaults = .standard) -> Bool {
+        Self.blobSeedClearedAt(userDefaults: userDefaults) != nil
+    }
+
     static func deleteRows(
         deviceID: String,
         providerID: String,

--- a/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
@@ -449,6 +449,10 @@ enum CostLedgerService {
         Self.blobSeedClearedAt(userDefaults: userDefaults) != nil
     }
 
+    static func blobSeedClearTombstoneDate(userDefaults: UserDefaults = .standard) -> Date? {
+        Self.blobSeedClearedAt(userDefaults: userDefaults)
+    }
+
     static func deleteRows(
         deviceID: String,
         providerID: String,

--- a/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
@@ -58,6 +58,13 @@ struct CostLedgerAggregation: Equatable {
     var sortedProviderRollups: [CostLedgerProviderRollup] {
         self.providerRollups.values.sorted { $0.providerID < $1.providerID }
     }
+
+    var hasDisplayData: Bool {
+        !self.providerRollups.isEmpty ||
+            !self.dailyPoints.isEmpty ||
+            !self.modelMix.isEmpty ||
+            !self.serviceMix.isEmpty
+    }
 }
 
 struct CostLedgerProviderRollup: Equatable {
@@ -334,6 +341,34 @@ enum CostLedgerService {
             serviceMix: serviceMix)
     }
 
+    /// Aggregate for default-on CWL readers. If the ledger is still empty but
+    /// existing synced blob snapshots are present, seed those blobs first and
+    /// re-run the aggregate so upgraded users do not briefly lose Cost history.
+    static func aggregateSeedingFromExistingBlobsIfNeeded(
+        windowDays: Int,
+        in context: ModelContext,
+        asOf: Date = Date(),
+        activeDeviceIDs: Set<String>? = nil) throws -> CostLedgerAggregation
+    {
+        let first = try Self.aggregate(
+            windowDays: windowDays,
+            in: context,
+            asOf: asOf,
+            activeDeviceIDs: activeDeviceIDs)
+        guard !first.hasDisplayData,
+              try Self.hasSeedableCostBlobs(in: context)
+        else {
+            return first
+        }
+
+        try Self.seedFromExistingBlobs(in: context)
+        return try Self.aggregate(
+            windowDays: windowDays,
+            in: context,
+            asOf: asOf,
+            activeDeviceIDs: activeDeviceIDs)
+    }
+
     /// Same as `aggregate(...)` but filtered to one provider. Used by
     /// `ProviderDetailView` (P4) — avoids materialising the cross-provider
     /// aggregate just to display a single provider's per-day cost section.
@@ -438,6 +473,12 @@ enum CostLedgerService {
             }
         }
         try context.save()
+    }
+
+    private static func hasSeedableCostBlobs(in context: ModelContext) throws -> Bool {
+        let descriptor = FetchDescriptor<ProviderSnapshotModel>(
+            predicate: #Predicate { $0.costSummaryData != nil })
+        return !(try context.fetch(descriptor)).isEmpty
     }
 
     // MARK: - Helpers

--- a/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
@@ -11,9 +11,10 @@ import SwiftData
 // they describe.
 //
 // Invariants:
-//   1. Default OFF. `isEnabled` reads `MobileSettingsKeys.cwlEnabled` from
-//      `UserDefaults.standard`. Until a user flips it (P4 UI), nothing in
-//      this file runs in production — build-140 behavior is identical.
+//   1. Default ON as of iOS 1.17.x. `isEnabled` reads
+//      `MobileSettingsKeys.cwlEnabled` from `UserDefaults.standard`, but
+//      treats an absent key as the product default so new users build a
+//      local ledger without visiting Settings first.
 //   2. Per-day uniqueness by `(deviceID, providerID, dayKey)`. Enforced via
 //      `DailyCostPoint.compositeKey` lookup before insert.
 //   3. Dedup rule: `existing.lastUpdated >= incoming.lastUpdated` → skip.
@@ -109,7 +110,10 @@ enum CostLedgerService {
     /// pass a per-suite `UserDefaults(suiteName:)` to verify the flag
     /// logic without touching the shared store.
     static func isEnabled(userDefaults: UserDefaults = .standard) -> Bool {
-        userDefaults.bool(forKey: MobileSettingsKeys.cwlEnabled)
+        guard userDefaults.object(forKey: MobileSettingsKeys.cwlEnabled) != nil else {
+            return MobileSettingsDefaults.cwlEnabled
+        }
+        return userDefaults.bool(forKey: MobileSettingsKeys.cwlEnabled)
     }
 
     // MARK: - Upsert: snapshot → daily rows

--- a/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
@@ -529,7 +529,6 @@ enum CostLedgerService {
         let providerKeys = Set(
             try context.fetch(FetchDescriptor<ProviderSnapshotModel>())
                 .map(\.compositeKey))
-        guard !providerKeys.isEmpty else { return }
 
         let rows = try context.fetch(FetchDescriptor<DailyCostPoint>())
         var didDelete = false

--- a/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/CostLedgerService.swift
@@ -133,14 +133,22 @@ enum CostLedgerService {
     /// snapshot for the current Mac window).
     ///
     /// All days in one call share `provider.lastUpdated` — the wire format
-    /// has no per-day timestamp.
+    /// has no per-day timestamp. If the user has explicitly cleared local
+    /// cost history, snapshots at or before that clear timestamp are skipped
+    /// so unchanged CloudKit data cannot immediately recreate deleted rows.
     static func upsertFromSnapshot(
         _ provider: ProviderUsageSnapshot,
         deviceID: String,
-        in context: ModelContext) throws
+        in context: ModelContext,
+        userDefaults: UserDefaults = .standard) throws
     {
         guard let summary = provider.costSummary else { return }
         guard !summary.daily.isEmpty else { return }
+        if let clearedAt = Self.blobSeedClearedAt(userDefaults: userDefaults),
+           provider.lastUpdated <= clearedAt
+        {
+            return
+        }
 
         let encoder = CloudSyncConstants.makeJSONEncoder()
         for point in summary.daily {

--- a/CodexBarMobile/CodexBarMobile/Storage/SwiftDataBridge.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/SwiftDataBridge.swift
@@ -69,18 +69,20 @@ enum SwiftDataBridge {
         try context.save()
     }
 
-    /// Upsert incrementally refreshed snapshots without treating the payload
-    /// as a complete mirror. Silent-push deltas may contain only changed
-    /// providers for a device, so this path must not prune missing providers
-    /// or missing devices.
-    static func upsertIncremental(
-        deviceSnapshots: [SyncedUsageSnapshot],
+    /// Mirror the cache state after an incremental refresh.
+    ///
+    /// `SnapshotCache.buildDeviceSnapshots()` supplies the complete, filtered
+    /// provider set for every included device. Missing providers are therefore
+    /// removed for those devices. The device array is not authoritative at the
+    /// global level, so devices absent from this call are preserved.
+    static func upsertIncrementalCacheMirror(
+        cacheDeviceSnapshots: [SyncedUsageSnapshot],
         deletedRecordNames: [String] = [],
         into context: ModelContext
     ) throws {
         try Self.deleteProviderRecords(named: deletedRecordNames, from: context)
-        for snapshot in deviceSnapshots {
-            try Self.upsertSnapshot(snapshot, into: context, pruneMissingProviders: false)
+        for snapshot in cacheDeviceSnapshots {
+            try Self.upsertSnapshot(snapshot, into: context)
         }
         try context.save()
     }
@@ -120,8 +122,7 @@ enum SwiftDataBridge {
 
     private static func upsertSnapshot(
         _ snapshot: SyncedUsageSnapshot,
-        into context: ModelContext,
-        pruneMissingProviders: Bool = true
+        into context: ModelContext
     ) throws {
         let deviceID = snapshot.deviceID ?? Self.deviceIDFallback(for: snapshot)
         let device = try Self.fetchOrCreateDevice(
@@ -150,18 +151,16 @@ enum SwiftDataBridge {
         // Prune rows that belonged to this device but disappeared from the
         // incoming snapshot. Cascade delete on the provider → utilization
         // relationship cleans up orphan entries automatically.
-        if pruneMissingProviders {
-            let staleDescriptor = FetchDescriptor<ProviderSnapshotModel>(
-                predicate: #Predicate { $0.deviceID == deviceID })
-            let existingForDevice = try context.fetch(staleDescriptor)
-            for existing in existingForDevice where !incomingKeys.contains(existing.compositeKey) {
-                context.delete(existing)
-                try CostLedgerService.deleteRows(
-                    deviceID: existing.deviceID,
-                    providerID: existing.providerID,
-                    accountEmail: existing.accountEmail,
-                    in: context)
-            }
+        let staleDescriptor = FetchDescriptor<ProviderSnapshotModel>(
+            predicate: #Predicate { $0.deviceID == deviceID })
+        let existingForDevice = try context.fetch(staleDescriptor)
+        for existing in existingForDevice where !incomingKeys.contains(existing.compositeKey) {
+            context.delete(existing)
+            try CostLedgerService.deleteRows(
+                deviceID: existing.deviceID,
+                providerID: existing.providerID,
+                accountEmail: existing.accountEmail,
+                in: context)
         }
 
         // Flush pending inserts/deletes so @Attribute(.unique) lookups resolve

--- a/CodexBarMobile/CodexBarMobile/Storage/SwiftDataBridge.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/SwiftDataBridge.swift
@@ -156,6 +156,11 @@ enum SwiftDataBridge {
             let existingForDevice = try context.fetch(staleDescriptor)
             for existing in existingForDevice where !incomingKeys.contains(existing.compositeKey) {
                 context.delete(existing)
+                try CostLedgerService.deleteRows(
+                    deviceID: existing.deviceID,
+                    providerID: existing.providerID,
+                    accountEmail: existing.accountEmail,
+                    in: context)
             }
         }
 

--- a/CodexBarMobile/CodexBarMobile/Storage/SwiftDataBridge.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/SwiftDataBridge.swift
@@ -75,11 +75,44 @@ enum SwiftDataBridge {
     /// or missing devices.
     static func upsertIncremental(
         deviceSnapshots: [SyncedUsageSnapshot],
+        deletedRecordNames: [String] = [],
         into context: ModelContext
     ) throws {
+        try Self.deleteProviderRecords(named: deletedRecordNames, from: context)
         for snapshot in deviceSnapshots {
             try Self.upsertSnapshot(snapshot, into: context, pruneMissingProviders: false)
         }
+        try context.save()
+    }
+
+    static func deleteProviderRecords(
+        named recordNames: [String],
+        from context: ModelContext
+    ) throws {
+        guard !recordNames.isEmpty else { return }
+
+        for recordName in recordNames {
+            guard let parsed = Self.splitProviderRecordName(recordName) else {
+                continue
+            }
+
+            let compositeKey = ProviderSnapshotModel.makeCompositeKey(
+                deviceID: parsed.deviceID,
+                providerID: parsed.providerID,
+                accountEmail: parsed.accountEmail)
+            let providerDescriptor = FetchDescriptor<ProviderSnapshotModel>(
+                predicate: #Predicate { $0.compositeKey == compositeKey })
+            for provider in try context.fetch(providerDescriptor) {
+                context.delete(provider)
+            }
+
+            try CostLedgerService.deleteRows(
+                deviceID: parsed.deviceID,
+                providerID: parsed.providerID,
+                accountEmail: parsed.accountEmail,
+                in: context)
+        }
+
         try context.save()
     }
 
@@ -396,6 +429,22 @@ enum SwiftDataBridge {
         }
 
         return snapshots
+    }
+
+    // MARK: - Provider record-name parsing
+
+    private static func splitProviderRecordName(_ recordName: String) -> (
+        deviceID: String,
+        providerID: String,
+        accountEmail: String?
+    )? {
+        let parts = recordName.split(separator: "|", omittingEmptySubsequences: false)
+        guard parts.count == 3 else { return nil }
+        let rawEmail = String(parts[2])
+        return (
+            deviceID: String(parts[0]),
+            providerID: String(parts[1]),
+            accountEmail: rawEmail == "_" ? nil : rawEmail)
     }
 
     // MARK: - Fallbacks

--- a/CodexBarMobile/CodexBarMobile/Storage/SwiftDataBridge.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/SwiftDataBridge.swift
@@ -206,11 +206,11 @@ enum SwiftDataBridge {
             into: model,
             context: context)
 
-        // Round 2 / P2 — Cost Window Ledger writer hook. Off by default; flag
-        // lives in `MobileSettingsKeys.cwlEnabled`. The blob path above always
-        // runs — even with CWL on the ledger and blob stay in sync (blob acts
-        // as the authoritative current-window snapshot, ledger accumulates a
-        // longer rolling history).
+        // Cost Window Ledger writer hook. The default-on flag lives in
+        // `MobileSettingsKeys.cwlEnabled`. The blob path above always runs —
+        // even with CWL on, the ledger and blob stay in sync (blob acts as the
+        // authoritative current-window snapshot, ledger accumulates a longer
+        // rolling history).
         if CostLedgerService.isEnabled() {
             try CostLedgerService.upsertFromSnapshot(
                 provider, deviceID: deviceID, in: context)

--- a/CodexBarMobile/CodexBarMobile/Storage/SwiftDataBridge.swift
+++ b/CodexBarMobile/CodexBarMobile/Storage/SwiftDataBridge.swift
@@ -69,11 +69,26 @@ enum SwiftDataBridge {
         try context.save()
     }
 
+    /// Upsert incrementally refreshed snapshots without treating the payload
+    /// as a complete mirror. Silent-push deltas may contain only changed
+    /// providers for a device, so this path must not prune missing providers
+    /// or missing devices.
+    static func upsertIncremental(
+        deviceSnapshots: [SyncedUsageSnapshot],
+        into context: ModelContext
+    ) throws {
+        for snapshot in deviceSnapshots {
+            try Self.upsertSnapshot(snapshot, into: context, pruneMissingProviders: false)
+        }
+        try context.save()
+    }
+
     // MARK: - Core upsert
 
     private static func upsertSnapshot(
         _ snapshot: SyncedUsageSnapshot,
-        into context: ModelContext
+        into context: ModelContext,
+        pruneMissingProviders: Bool = true
     ) throws {
         let deviceID = snapshot.deviceID ?? Self.deviceIDFallback(for: snapshot)
         let device = try Self.fetchOrCreateDevice(
@@ -102,11 +117,13 @@ enum SwiftDataBridge {
         // Prune rows that belonged to this device but disappeared from the
         // incoming snapshot. Cascade delete on the provider → utilization
         // relationship cleans up orphan entries automatically.
-        let staleDescriptor = FetchDescriptor<ProviderSnapshotModel>(
-            predicate: #Predicate { $0.deviceID == deviceID })
-        let existingForDevice = try context.fetch(staleDescriptor)
-        for existing in existingForDevice where !incomingKeys.contains(existing.compositeKey) {
-            context.delete(existing)
+        if pruneMissingProviders {
+            let staleDescriptor = FetchDescriptor<ProviderSnapshotModel>(
+                predicate: #Predicate { $0.deviceID == deviceID })
+            let existingForDevice = try context.fetch(staleDescriptor)
+            for existing in existingForDevice where !incomingKeys.contains(existing.compositeKey) {
+                context.delete(existing)
+            }
         }
 
         // Flush pending inserts/deletes so @Attribute(.unique) lookups resolve

--- a/CodexBarMobile/CodexBarMobile/iCloud/CloudSyncReader.swift
+++ b/CodexBarMobile/CodexBarMobile/iCloud/CloudSyncReader.swift
@@ -145,14 +145,14 @@ final class CloudSyncReader: @unchecked Sendable {
         }
     }
 
-    static func persistIncrementalToSwiftData(
-        deviceSnapshots: [SyncedUsageSnapshot],
+    static func persistIncrementalCacheMirrorToSwiftData(
+        cacheDeviceSnapshots: [SyncedUsageSnapshot],
         deletedRecordNames: [String] = [],
         context: ModelContext
     ) {
         do {
-            try SwiftDataBridge.upsertIncremental(
-                deviceSnapshots: deviceSnapshots,
+            try SwiftDataBridge.upsertIncrementalCacheMirror(
+                cacheDeviceSnapshots: cacheDeviceSnapshots,
                 deletedRecordNames: deletedRecordNames,
                 into: context)
         } catch {

--- a/CodexBarMobile/CodexBarMobile/iCloud/CloudSyncReader.swift
+++ b/CodexBarMobile/CodexBarMobile/iCloud/CloudSyncReader.swift
@@ -147,11 +147,13 @@ final class CloudSyncReader: @unchecked Sendable {
 
     static func persistIncrementalToSwiftData(
         deviceSnapshots: [SyncedUsageSnapshot],
+        deletedRecordNames: [String] = [],
         context: ModelContext
     ) {
         do {
             try SwiftDataBridge.upsertIncremental(
                 deviceSnapshots: deviceSnapshots,
+                deletedRecordNames: deletedRecordNames,
                 into: context)
         } catch {
             print("[CodexBar SwiftData] Incremental upsert failed: \(error)")

--- a/CodexBarMobile/CodexBarMobile/iCloud/CloudSyncReader.swift
+++ b/CodexBarMobile/CodexBarMobile/iCloud/CloudSyncReader.swift
@@ -145,6 +145,19 @@ final class CloudSyncReader: @unchecked Sendable {
         }
     }
 
+    static func persistIncrementalToSwiftData(
+        deviceSnapshots: [SyncedUsageSnapshot],
+        context: ModelContext
+    ) {
+        do {
+            try SwiftDataBridge.upsertIncremental(
+                deviceSnapshots: deviceSnapshots,
+                into: context)
+        } catch {
+            print("[CodexBar SwiftData] Incremental upsert failed: \(error)")
+        }
+    }
+
     // MARK: - Multi-device merge
 
     static func mergeSnapshots(

--- a/CodexBarMobile/CodexBarMobileTests/CodexBarWidgetRenderMatrixTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CodexBarWidgetRenderMatrixTests.swift
@@ -106,6 +106,19 @@ final class CodexBarWidgetRenderMatrixTests: XCTestCase {
         }
     }
 
+    func testLoadedFooterLineIsAlwaysCentered() throws {
+        let sourceURL = Self.sourceFileURL(
+            forRelative: "CodexBarMobile/CodexBarWidgetShared/CodexBarWidgetView.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        XCTAssertTrue(
+            source.contains("private var footerAlignment: Alignment {\n        .center\n    }"),
+            "The loaded `Updated ...` footer must stay centered for every widget mode and family.")
+        XCTAssertFalse(
+            source.contains("return .leading"),
+            "Do not reintroduce mode/family-specific leading alignment for the loaded footer.")
+    }
+
     private func renderWidget(
         mode: CodexBarWidgetMode,
         colorStyle: CodexBarWidgetColorStyle,
@@ -136,6 +149,16 @@ final class CodexBarWidgetRenderMatrixTests: XCTestCase {
         let renderer = ImageRenderer(content: view)
         renderer.scale = 2.0
         return renderer.uiImage
+    }
+
+    private static func sourceFileURL(forRelative relativePath: String) -> URL {
+        var url = URL(fileURLWithPath: #filePath)
+        let parts = url.pathComponents
+        guard let idx = parts.lastIndex(of: "CodexBarMobile") else {
+            return URL(fileURLWithPath: relativePath)
+        }
+        let root = URL(fileURLWithPath: parts[..<idx].joined(separator: "/"), isDirectory: true)
+        return root.appendingPathComponent(relativePath)
     }
 
     @discardableResult

--- a/CodexBarMobile/CodexBarMobileTests/CostDiagnosticsReportTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostDiagnosticsReportTests.swift
@@ -162,6 +162,30 @@ struct CostDiagnosticsReportTests {
         #expect(report.providerRules.map(\.providerID) == ["codex"])
     }
 
+    @Test("Snapshot diagnostics default missing history to 30 days")
+    func snapshotDiagnosticsDefaultMissingHistoryToThirtyDays() throws {
+        let snapshot = SyncedUsageSnapshot(
+            providers: [
+                self.provider(id: "codex", name: "Codex", cost: 12, tokens: 1_200, historyDays: nil),
+            ],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+        let insights = CostDashboardInsights(snapshot: snapshot)
+
+        let report = CostDiagnosticsReport.make(
+            insights: insights,
+            snapshot: snapshot,
+            rawDeviceSnapshots: [snapshot],
+            activeDeviceSnapshots: [snapshot],
+            cwlEnabled: true,
+            cwlWindowDays: 90,
+            ledgerAvailable: false)
+
+        #expect(report.dataSource == .syncedSnapshotsAfterLedgerFailure)
+        #expect(report.windowDays == 30)
+    }
+
     private func day(daysAgo: Int, cost: Double, tokens: Int) -> CostDashboardInsights.DailyPoint {
         let date = Calendar.current.date(byAdding: .day, value: -daysAgo, to: self.now) ?? self.now
         return CostDashboardInsights.DailyPoint(
@@ -183,7 +207,13 @@ struct CostDiagnosticsReportTests {
             serviceMix: [])
     }
 
-    private func provider(id: String, name: String, cost: Double, tokens: Int) -> ProviderUsageSnapshot {
+    private func provider(
+        id: String,
+        name: String,
+        cost: Double,
+        tokens: Int,
+        historyDays: Int? = 30) -> ProviderUsageSnapshot
+    {
         let dayKey = SyncCostSummary.iso8601DayKey(for: self.now)
         let daily = SyncDailyPoint(
             dayKey: dayKey,
@@ -209,6 +239,6 @@ struct CostDiagnosticsReportTests {
                 last30DaysTokens: tokens,
                 daily: [daily],
                 isEstimated: false,
-                historyDays: 30))
+                historyDays: historyDays))
     }
 }

--- a/CodexBarMobile/CodexBarMobileTests/CostDiagnosticsReportTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostDiagnosticsReportTests.swift
@@ -139,6 +139,67 @@ struct CostDiagnosticsReportTests {
         #expect(report.checks.first(where: { $0.kind == .shareCard })?.status == .pass)
     }
 
+    @Test("Report does not compare 7-day overview against 30-day share card")
+    func shareCardCheckPassesForShorterLedgerWindow() throws {
+        let summaryDays = (0..<30).map { day in
+            self.syncDay(daysAgo: day, cost: 1, tokens: 100)
+        }
+        let ledgerDays = (0..<7).map { day in
+            self.day(daysAgo: day, cost: 1, tokens: 100)
+        }
+        let provider = ProviderUsageSnapshot(
+            providerID: "codex",
+            providerName: "Codex",
+            primary: nil,
+            secondary: nil,
+            accountEmail: nil,
+            loginMethod: nil,
+            statusMessage: nil,
+            isError: false,
+            lastUpdated: self.now,
+            costSummary: SyncCostSummary(
+                sessionCostUSD: nil,
+                sessionTokens: nil,
+                last30DaysCostUSD: 30,
+                last30DaysTokens: 3_000,
+                daily: summaryDays,
+                isEstimated: false,
+                historyDays: 30))
+        let insights = CostDashboardInsights(
+            providerRows: [
+                CostDashboardInsights.ProviderRow(
+                    provider: provider,
+                    thirtyDayCost: 7,
+                    todayCost: 1,
+                    thirtyDayTokens: 700,
+                    todayTokens: 100,
+                    dailyPoints: ledgerDays),
+            ],
+            dailyPoints: ledgerDays,
+            modelRows: [],
+            serviceRows: [],
+            budgetRows: [],
+            cwlWindowDays: 7)
+        let snapshot = SyncedUsageSnapshot(
+            providers: [provider],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+
+        let report = CostDiagnosticsReport.make(
+            insights: insights,
+            snapshot: snapshot,
+            rawDeviceSnapshots: [snapshot],
+            activeDeviceSnapshots: [snapshot],
+            cwlEnabled: true,
+            cwlWindowDays: 7,
+            ledgerAvailable: true)
+
+        #expect(report.totalCostUSD == 7)
+        #expect(report.windowDays == 7)
+        #expect(report.checks.first(where: { $0.kind == .shareCard })?.status == .pass)
+    }
+
     @Test("Diagnostics reuse Cost tab fallback when ledger is empty")
     func diagnosticsReuseCostTabFallbackForEmptyLedger() throws {
         let snapshot = SyncedUsageSnapshot(
@@ -193,6 +254,17 @@ struct CostDiagnosticsReportTests {
             date: date,
             costUSD: cost,
             totalTokens: tokens)
+    }
+
+    private func syncDay(daysAgo: Int, cost: Double, tokens: Int) -> SyncDailyPoint {
+        let date = Calendar.current.date(byAdding: .day, value: -daysAgo, to: self.now) ?? self.now
+        return SyncDailyPoint(
+            dayKey: SyncCostSummary.iso8601DayKey(for: date),
+            costUSD: cost,
+            totalTokens: tokens,
+            modelBreakdowns: [],
+            serviceBreakdowns: [],
+            isEstimated: false)
     }
 
     private func emptyAggregation(windowDays: Int) -> CostLedgerAggregation {

--- a/CodexBarMobile/CodexBarMobileTests/CostDiagnosticsReportTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostDiagnosticsReportTests.swift
@@ -1,0 +1,121 @@
+import CodexBarSync
+import Foundation
+import Testing
+@testable import CodexBarMobile
+
+@Suite("Cost Diagnostics report")
+@MainActor
+struct CostDiagnosticsReportTests {
+    private let now = Date()
+
+    @Test("Report identifies local-cost and account-level provider rules")
+    func providerRulesUseCorrectMergeSemantics() throws {
+        let snapshot = SyncedUsageSnapshot(
+            providers: [
+                self.provider(id: "codex", name: "Codex", cost: 4, tokens: 400),
+                self.provider(id: "openai", name: "OpenAI", cost: 6, tokens: 600),
+            ],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+        let insights = CostDashboardInsights(snapshot: snapshot)
+
+        let report = CostDiagnosticsReport.make(
+            insights: insights,
+            snapshot: snapshot,
+            rawDeviceSnapshots: [snapshot],
+            activeDeviceSnapshots: [snapshot],
+            cwlEnabled: true,
+            cwlWindowDays: 90,
+            ledgerAvailable: true)
+
+        let rules = Dictionary(uniqueKeysWithValues: report.providerRules.map { ($0.providerID, $0.rule) })
+        #expect(rules["codex"] == .sumActiveDevices)
+        #expect(rules["openai"] == .latestAccountDay)
+        #expect(report.dataSource == .localLedger)
+        #expect(report.windowDays == 30)
+    }
+
+    @Test("Report reconciles provider share and share cards against Overview")
+    func reconciliationPassesForConsistentCostData() throws {
+        let snapshot = SyncedUsageSnapshot(
+            providers: [
+                self.provider(id: "codex", name: "Codex", cost: 4, tokens: 400),
+                self.provider(id: "claude", name: "Claude", cost: 6, tokens: 600),
+            ],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+        let insights = CostDashboardInsights(snapshot: snapshot)
+
+        let report = CostDiagnosticsReport.make(
+            insights: insights,
+            snapshot: snapshot,
+            rawDeviceSnapshots: [snapshot],
+            activeDeviceSnapshots: [snapshot],
+            cwlEnabled: false,
+            cwlWindowDays: 90,
+            ledgerAvailable: false)
+
+        #expect(report.totalCostUSD == 10)
+        #expect(report.todayCostUSD == 10)
+        #expect(report.activeDeviceCount == 1)
+        #expect(report.excludedDeviceCount == 0)
+        #expect(report.checks.first(where: { $0.kind == .providerShare })?.status == .pass)
+        #expect(report.checks.first(where: { $0.kind == .shareCard })?.status == .pass)
+    }
+
+    @Test("Report provider rules keep unique row IDs for duplicate provider rows")
+    func providerRuleIDsStayUniqueForDuplicateProviderRows() throws {
+        let snapshot = SyncedUsageSnapshot(
+            providers: [
+                self.provider(id: "openai", name: "OpenAI", cost: 1, tokens: 100),
+                self.provider(id: "openai", name: "OpenAI", cost: 2, tokens: 200),
+            ],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+        let insights = CostDashboardInsights(snapshot: snapshot)
+
+        let report = CostDiagnosticsReport.make(
+            insights: insights,
+            snapshot: snapshot,
+            rawDeviceSnapshots: [snapshot],
+            activeDeviceSnapshots: [snapshot],
+            cwlEnabled: true,
+            cwlWindowDays: 90,
+            ledgerAvailable: true)
+
+        #expect(report.providerRules.count == 2)
+        #expect(Set(report.providerRules.map(\.id)).count == report.providerRules.count)
+    }
+
+    private func provider(id: String, name: String, cost: Double, tokens: Int) -> ProviderUsageSnapshot {
+        let dayKey = SyncCostSummary.iso8601DayKey(for: self.now)
+        let daily = SyncDailyPoint(
+            dayKey: dayKey,
+            costUSD: cost,
+            totalTokens: tokens,
+            modelBreakdowns: [SyncCostBreakdown(label: "\(name) Model", costUSD: cost)],
+            serviceBreakdowns: id == "codex" ? [SyncCostBreakdown(label: "Codex Run", costUSD: cost)] : [],
+            isEstimated: false)
+        return ProviderUsageSnapshot(
+            providerID: id,
+            providerName: name,
+            primary: nil,
+            secondary: nil,
+            accountEmail: nil,
+            loginMethod: nil,
+            statusMessage: nil,
+            isError: false,
+            lastUpdated: self.now,
+            costSummary: SyncCostSummary(
+                sessionCostUSD: cost,
+                sessionTokens: tokens,
+                last30DaysCostUSD: cost,
+                last30DaysTokens: tokens,
+                daily: [daily],
+                isEstimated: false,
+                historyDays: 30))
+    }
+}

--- a/CodexBarMobile/CodexBarMobileTests/CostDiagnosticsReportTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostDiagnosticsReportTests.swift
@@ -90,6 +90,64 @@ struct CostDiagnosticsReportTests {
         #expect(Set(report.providerRules.map(\.id)).count == report.providerRules.count)
     }
 
+    @Test("Report does not compare 90-day overview against 30-day share card")
+    func shareCardCheckPassesForWiderLedgerWindow() throws {
+        let oldPoint = self.day(daysAgo: 45, cost: 70, tokens: 7_000)
+        let recentPoint = self.day(daysAgo: 3, cost: 30, tokens: 3_000)
+        let provider = ProviderUsageSnapshot(
+            providerID: "codex",
+            providerName: "Codex",
+            primary: nil,
+            secondary: nil,
+            accountEmail: nil,
+            loginMethod: nil,
+            statusMessage: nil,
+            isError: false,
+            lastUpdated: self.now,
+            costSummary: nil)
+        let insights = CostDashboardInsights(
+            providerRows: [
+                CostDashboardInsights.ProviderRow(
+                    provider: provider,
+                    thirtyDayCost: 100,
+                    todayCost: 0,
+                    thirtyDayTokens: 10_000,
+                    todayTokens: 0,
+                    dailyPoints: [oldPoint, recentPoint]),
+            ],
+            dailyPoints: [oldPoint, recentPoint],
+            modelRows: [],
+            serviceRows: [],
+            budgetRows: [],
+            cwlWindowDays: 90)
+        let snapshot = SyncedUsageSnapshot(
+            providers: [provider],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+
+        let report = CostDiagnosticsReport.make(
+            insights: insights,
+            snapshot: snapshot,
+            rawDeviceSnapshots: [snapshot],
+            activeDeviceSnapshots: [snapshot],
+            cwlEnabled: true,
+            cwlWindowDays: 90,
+            ledgerAvailable: true)
+
+        #expect(report.totalCostUSD == 100)
+        #expect(report.checks.first(where: { $0.kind == .shareCard })?.status == .pass)
+    }
+
+    private func day(daysAgo: Int, cost: Double, tokens: Int) -> CostDashboardInsights.DailyPoint {
+        let date = Calendar.current.date(byAdding: .day, value: -daysAgo, to: self.now) ?? self.now
+        return CostDashboardInsights.DailyPoint(
+            dayKey: SyncCostSummary.iso8601DayKey(for: date),
+            date: date,
+            costUSD: cost,
+            totalTokens: tokens)
+    }
+
     private func provider(id: String, name: String, cost: Double, tokens: Int) -> ProviderUsageSnapshot {
         let dayKey = SyncCostSummary.iso8601DayKey(for: self.now)
         let daily = SyncDailyPoint(

--- a/CodexBarMobile/CodexBarMobileTests/CostDiagnosticsReportTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostDiagnosticsReportTests.swift
@@ -139,6 +139,29 @@ struct CostDiagnosticsReportTests {
         #expect(report.checks.first(where: { $0.kind == .shareCard })?.status == .pass)
     }
 
+    @Test("Diagnostics reuse Cost tab fallback when ledger is empty")
+    func diagnosticsReuseCostTabFallbackForEmptyLedger() throws {
+        let snapshot = SyncedUsageSnapshot(
+            providers: [
+                self.provider(id: "codex", name: "Codex", cost: 12, tokens: 1_200),
+            ],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+        let report = try #require(CostDiagnosticsReportResolver.make(
+            snapshot: snapshot,
+            ledgerAggregation: self.emptyAggregation(windowDays: 90),
+            rawDeviceSnapshots: [snapshot],
+            activeDeviceSnapshots: [snapshot],
+            cwlEnabled: true,
+            cwlWindowDays: 90,
+            localHistoryClearedAt: nil))
+
+        #expect(report.totalCostUSD == 12)
+        #expect(report.dataSource == .syncedSnapshotsAfterLedgerFailure)
+        #expect(report.providerRules.map(\.providerID) == ["codex"])
+    }
+
     private func day(daysAgo: Int, cost: Double, tokens: Int) -> CostDashboardInsights.DailyPoint {
         let date = Calendar.current.date(byAdding: .day, value: -daysAgo, to: self.now) ?? self.now
         return CostDashboardInsights.DailyPoint(
@@ -146,6 +169,18 @@ struct CostDiagnosticsReportTests {
             date: date,
             costUSD: cost,
             totalTokens: tokens)
+    }
+
+    private func emptyAggregation(windowDays: Int) -> CostLedgerAggregation {
+        CostLedgerAggregation(
+            windowDays: windowDays,
+            totalCostUSD: 0,
+            totalTokens: 0,
+            activeDayCount: 0,
+            providerRollups: [:],
+            dailyPoints: [],
+            modelMix: [],
+            serviceMix: [])
     }
 
     private func provider(id: String, name: String, cost: Double, tokens: Int) -> ProviderUsageSnapshot {

--- a/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
@@ -7,7 +7,14 @@ import Testing
 struct CostShareServiceTests {
     private static let tolerance = 0.001
 
-    private func provider(id: String, name: String, sessionTokens: Int? = nil) -> ProviderUsageSnapshot {
+    private func provider(
+        id: String,
+        name: String,
+        sessionTokens: Int? = nil,
+        thirtyDayCost: Double? = nil,
+        thirtyDayTokens: Int? = nil,
+        historyDays: Int? = nil
+    ) -> ProviderUsageSnapshot {
         ProviderUsageSnapshot(
             providerID: id,
             providerName: name,
@@ -21,9 +28,10 @@ struct CostShareServiceTests {
             costSummary: SyncCostSummary(
                 sessionCostUSD: nil,
                 sessionTokens: sessionTokens,
-                last30DaysCostUSD: nil,
-                last30DaysTokens: nil,
-                daily: []))
+                last30DaysCostUSD: thirtyDayCost,
+                last30DaysTokens: thirtyDayTokens,
+                daily: [],
+                historyDays: historyDays))
     }
 
     private func day(daysAgo: Int, cost: Double, tokens: Int) -> CostDashboardInsights.DailyPoint {
@@ -153,6 +161,52 @@ struct CostShareServiceTests {
         #expect(monthly.providers.count == 1)
         #expect(abs((codexShare?.cost ?? 0) - 30) < Self.tolerance)
         #expect(monthly.dailyBars.count == 2)
+    }
+
+    @Test("Share card 30-day period preserves summary-only provider costs")
+    func shareCardMonthPreservesSummaryOnlyProviderCosts() {
+        let codex = CostDashboardInsights.ProviderRow(
+            provider: self.provider(
+                id: "codex",
+                name: "Codex",
+                thirtyDayCost: 42,
+                thirtyDayTokens: 4_200,
+                historyDays: 30),
+            thirtyDayCost: 42,
+            todayCost: 0,
+            thirtyDayTokens: 4_200,
+            todayTokens: 0,
+            dailyPoints: [])
+        let claude = CostDashboardInsights.ProviderRow(
+            provider: self.provider(
+                id: "claude",
+                name: "Claude",
+                thirtyDayCost: 8,
+                thirtyDayTokens: 800,
+                historyDays: 30),
+            thirtyDayCost: 8,
+            todayCost: 0,
+            thirtyDayTokens: 800,
+            todayTokens: 0,
+            dailyPoints: [])
+        let insights = CostDashboardInsights(
+            providerRows: [codex, claude],
+            dailyPoints: [],
+            modelRows: [],
+            serviceRows: [],
+            budgetRows: [])
+
+        let monthly = ShareCardData(insights: insights, period: .month)
+        let codexShare = monthly.providers.first { $0.name == "Codex" }
+        let claudeShare = monthly.providers.first { $0.name == "Claude" }
+
+        #expect(abs(monthly.totalCost - 50) < Self.tolerance)
+        #expect(monthly.totalTokens == 5_000)
+        #expect(monthly.providers.count == 2)
+        #expect(abs((codexShare?.cost ?? 0) - 42) < Self.tolerance)
+        #expect(abs((claudeShare?.cost ?? 0) - 8) < Self.tolerance)
+        #expect(abs((codexShare?.share ?? 0) - 0.84) < Self.tolerance)
+        #expect(abs((claudeShare?.share ?? 0) - 0.16) < Self.tolerance)
     }
 
     @Test("Share card Today tokens use resolved daily totals, not stale session tokens")

--- a/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
@@ -111,6 +111,50 @@ struct CostShareServiceTests {
         #expect(abs((claudeShare?.share ?? 0) - 0.2) < Self.tolerance)
     }
 
+    @Test("Share card 30-day period caps wider CWL insights to the last 30 days")
+    func shareCardMonthCapsWiderLedgerWindow() {
+        let codexToday = self.day(daysAgo: 0, cost: 10, tokens: 100)
+        let codexDay29 = self.day(daysAgo: 29, cost: 20, tokens: 200)
+        let codexDay30 = self.day(daysAgo: 30, cost: 100, tokens: 1_000)
+        let claudeDay30 = self.day(daysAgo: 30, cost: 50, tokens: 500)
+
+        let codex = CostDashboardInsights.ProviderRow(
+            provider: self.provider(id: "codex", name: "Codex"),
+            thirtyDayCost: 130,
+            todayCost: 10,
+            thirtyDayTokens: 1_300,
+            todayTokens: 100,
+            dailyPoints: [codexToday, codexDay29, codexDay30])
+        let claude = CostDashboardInsights.ProviderRow(
+            provider: self.provider(id: "claude", name: "Claude"),
+            thirtyDayCost: 50,
+            todayCost: 0,
+            thirtyDayTokens: 500,
+            todayTokens: 0,
+            dailyPoints: [claudeDay30])
+        let insights = CostDashboardInsights(
+            providerRows: [codex, claude],
+            dailyPoints: [
+                self.day(daysAgo: 0, cost: 10, tokens: 100),
+                self.day(daysAgo: 29, cost: 20, tokens: 200),
+                self.day(daysAgo: 30, cost: 150, tokens: 1_500),
+            ],
+            modelRows: [],
+            serviceRows: [],
+            budgetRows: [],
+            cwlWindowDays: 90)
+
+        let monthly = ShareCardData(insights: insights, period: .month)
+        let codexShare = monthly.providers.first { $0.name == "Codex" }
+
+        #expect(abs(monthly.totalCost - 30) < Self.tolerance)
+        #expect(monthly.totalTokens == 300)
+        #expect(monthly.activeDays == 2)
+        #expect(monthly.providers.count == 1)
+        #expect(abs((codexShare?.cost ?? 0) - 30) < Self.tolerance)
+        #expect(monthly.dailyBars.count == 2)
+    }
+
     @Test("Share card Today tokens use resolved daily totals, not stale session tokens")
     func shareCardTodayTokensUseResolvedDailyTotals() {
         let codex = CostDashboardInsights.ProviderRow(

--- a/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
@@ -505,11 +505,19 @@ struct CostShareServiceTests {
     @Test("Share card 30-day period uses summary daily bars when local window is shorter")
     func shareCardMonthUsesSummaryDailyBarsForShorterLedgerWindow() {
         let summaryDays = (0..<30).map { day in
-            self.summaryDay(
+            let model = day < 7 ? "recent-model" : "older-month-model"
+            return self.summaryDay(
                 daysAgo: day,
                 cost: 1,
                 tokens: 100,
-                models: [])
+                models: [SyncCostBreakdown(label: model, costUSD: 1)])
+        }
+        let ledgerDays = (0..<7).map { day in
+            self.day(
+                daysAgo: day,
+                cost: 1,
+                tokens: 100,
+                models: [SyncCostBreakdown(label: "recent-model", costUSD: 1)])
         }
         let codex = CostDashboardInsights.ProviderRow(
             provider: self.provider(
@@ -523,11 +531,13 @@ struct CostShareServiceTests {
             todayCost: 1,
             thirtyDayTokens: 700,
             todayTokens: 100,
-            dailyPoints: (0..<7).map { self.day(daysAgo: $0, cost: 1, tokens: 100) })
+            dailyPoints: ledgerDays)
         let insights = CostDashboardInsights(
             providerRows: [codex],
-            dailyPoints: (0..<7).map { self.day(daysAgo: $0, cost: 1, tokens: 100) },
-            modelRows: [],
+            dailyPoints: ledgerDays,
+            modelRows: [
+                CostBreakdownRow(label: "recent-model", amountUSD: 7, subtitle: nil, color: .blue),
+            ],
             serviceRows: [],
             budgetRows: [],
             cwlWindowDays: 7)
@@ -539,6 +549,59 @@ struct CostShareServiceTests {
         #expect(monthly.activeDays == 30)
         #expect(monthly.dailyBars.count == 30)
         #expect(abs(monthly.dailyBars.reduce(0) { $0 + $1.cost } - 30) < Self.tolerance)
+        #expect(monthly.topModels.map(\.label) == ["older-month-model", "recent-model"])
+        #expect(abs((monthly.topModels.first?.cost ?? 0) - 23) < Self.tolerance)
+    }
+
+    @Test("Share card uses monthly models when short-window and summary totals are equal")
+    func shareCardMonthUsesSummaryModelsForEqualTotals() {
+        let summaryDay = self.summaryDay(
+            daysAgo: 10,
+            cost: 7,
+            tokens: 700,
+            models: [SyncCostBreakdown(label: "monthly-model", costUSD: 7)])
+        let ledgerDay = self.day(
+            daysAgo: 0,
+            cost: 7,
+            tokens: 700,
+            models: [SyncCostBreakdown(label: "ledger-model", costUSD: 7)])
+        let codex = CostDashboardInsights.ProviderRow(
+            provider: ProviderUsageSnapshot(
+                providerID: "codex",
+                providerName: "Codex",
+                primary: nil,
+                secondary: nil,
+                accountEmail: nil,
+                loginMethod: nil,
+                statusMessage: nil,
+                isError: false,
+                lastUpdated: Date(),
+                costSummary: SyncCostSummary(
+                    sessionCostUSD: nil,
+                    sessionTokens: nil,
+                    last30DaysCostUSD: 90,
+                    last30DaysTokens: 9_000,
+                    daily: [summaryDay],
+                    historyDays: 90)),
+            thirtyDayCost: 7,
+            todayCost: 7,
+            thirtyDayTokens: 700,
+            todayTokens: 700,
+            dailyPoints: [ledgerDay])
+        let insights = CostDashboardInsights(
+            providerRows: [codex],
+            dailyPoints: [ledgerDay],
+            modelRows: [
+                CostBreakdownRow(label: "ledger-model", amountUSD: 7, subtitle: nil, color: .blue),
+            ],
+            serviceRows: [],
+            budgetRows: [],
+            cwlWindowDays: 7)
+
+        let monthly = ShareCardData(insights: insights, period: .month)
+
+        #expect(monthly.totalCost == 7)
+        #expect(monthly.topModels.map(\.label) == ["monthly-model"])
     }
 
     @Test("Share card Today tokens use resolved daily totals, not stale session tokens")

--- a/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
@@ -320,6 +320,62 @@ struct CostShareServiceTests {
         #expect(abs((monthly.topModels.first?.share ?? 0) - 0.6) < Self.tolerance)
     }
 
+    @Test("Share card summary daily bars include ledger-only provider days")
+    func shareCardSummaryDailyBarsIncludeLedgerOnlyProviderDays() {
+        let summaryDay = self.summaryDay(
+            daysAgo: 0,
+            cost: 30,
+            tokens: 3_000,
+            models: [])
+        let codex = CostDashboardInsights.ProviderRow(
+            provider: self.provider(
+                id: "codex",
+                name: "Codex",
+                thirtyDayCost: 30,
+                thirtyDayTokens: 3_000,
+                historyDays: 30,
+                daily: [summaryDay]),
+            thirtyDayCost: 1,
+            todayCost: 1,
+            thirtyDayTokens: 100,
+            todayTokens: 100,
+            dailyPoints: [self.day(daysAgo: 0, cost: 1, tokens: 100)])
+        let claude = CostDashboardInsights.ProviderRow(
+            provider: ProviderUsageSnapshot(
+                providerID: "claude",
+                providerName: "Claude",
+                primary: nil,
+                secondary: nil,
+                accountEmail: nil,
+                loginMethod: nil,
+                statusMessage: nil,
+                isError: false,
+                lastUpdated: Date(),
+                costSummary: nil),
+            thirtyDayCost: 6,
+            todayCost: 0,
+            thirtyDayTokens: 600,
+            todayTokens: 0,
+            dailyPoints: [self.day(daysAgo: 1, cost: 6, tokens: 600)])
+        let insights = CostDashboardInsights(
+            providerRows: [codex, claude],
+            dailyPoints: [
+                self.day(daysAgo: 0, cost: 1, tokens: 100),
+                self.day(daysAgo: 1, cost: 6, tokens: 600),
+            ],
+            modelRows: [],
+            serviceRows: [],
+            budgetRows: [],
+            cwlWindowDays: 90)
+
+        let monthly = ShareCardData(insights: insights, period: .month)
+
+        #expect(abs(monthly.totalCost - 36) < Self.tolerance)
+        #expect(monthly.activeDays == 2)
+        #expect(monthly.dailyBars.count == 2)
+        #expect(abs(monthly.dailyBars.reduce(0) { $0 + $1.cost } - 36) < Self.tolerance)
+    }
+
     @Test("Share card 30-day period preserves summary-only provider costs")
     func shareCardMonthPreservesSummaryOnlyProviderCosts() {
         let codex = CostDashboardInsights.ProviderRow(

--- a/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
@@ -1,5 +1,6 @@
 import CodexBarSync
 import Foundation
+import SwiftUI
 import Testing
 @testable import CodexBarMobile
 
@@ -13,7 +14,8 @@ struct CostShareServiceTests {
         sessionTokens: Int? = nil,
         thirtyDayCost: Double? = nil,
         thirtyDayTokens: Int? = nil,
-        historyDays: Int? = nil
+        historyDays: Int? = nil,
+        daily: [SyncDailyPoint] = []
     ) -> ProviderUsageSnapshot {
         ProviderUsageSnapshot(
             providerID: id,
@@ -30,7 +32,7 @@ struct CostShareServiceTests {
                 sessionTokens: sessionTokens,
                 last30DaysCostUSD: thirtyDayCost,
                 last30DaysTokens: thirtyDayTokens,
-                daily: [],
+                daily: daily,
                 historyDays: historyDays))
     }
 
@@ -44,6 +46,23 @@ struct CostShareServiceTests {
             date: date,
             costUSD: cost,
             totalTokens: tokens)
+    }
+
+    private func summaryDay(
+        daysAgo: Int,
+        cost: Double,
+        tokens: Int,
+        models: [SyncCostBreakdown]
+    ) -> SyncDailyPoint {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let date = calendar.date(byAdding: .day, value: -daysAgo, to: today)!
+        let formatter = SyncCostSummary.iso8601DayKeyFormatter()
+        return SyncDailyPoint(
+            dayKey: formatter.string(from: date),
+            costUSD: cost,
+            totalTokens: tokens,
+            modelBreakdowns: models)
     }
 
     @Test("Provider Share filters zero-spend rows but keeps spend totals intact")
@@ -161,6 +180,53 @@ struct CostShareServiceTests {
         #expect(monthly.providers.count == 1)
         #expect(abs((codexShare?.cost ?? 0) - 30) < Self.tolerance)
         #expect(monthly.dailyBars.count == 2)
+    }
+
+    @Test("Share card 30-day period caps top models to the same window")
+    func shareCardMonthCapsTopModelsToThirtyDays() {
+        let recentModel = SyncCostBreakdown(label: "recent-model", costUSD: 3)
+        let oldModel = SyncCostBreakdown(label: "old-model", costUSD: 9)
+        let recentSummaryDay = self.summaryDay(
+            daysAgo: 0,
+            cost: 3,
+            tokens: 300,
+            models: [recentModel])
+        let oldSummaryDay = self.summaryDay(
+            daysAgo: 45,
+            cost: 9,
+            tokens: 900,
+            models: [oldModel])
+        let codex = CostDashboardInsights.ProviderRow(
+            provider: self.provider(
+                id: "codex",
+                name: "Codex",
+                daily: [recentSummaryDay, oldSummaryDay]),
+            thirtyDayCost: 12,
+            todayCost: 3,
+            thirtyDayTokens: 1_200,
+            todayTokens: 300,
+            dailyPoints: [
+                self.day(daysAgo: 0, cost: 3, tokens: 300),
+                self.day(daysAgo: 45, cost: 9, tokens: 900),
+            ])
+        let insights = CostDashboardInsights(
+            providerRows: [codex],
+            dailyPoints: [
+                self.day(daysAgo: 0, cost: 3, tokens: 300),
+                self.day(daysAgo: 45, cost: 9, tokens: 900),
+            ],
+            modelRows: [
+                CostBreakdownRow(label: "old-model", amountUSD: 9, subtitle: nil, color: .blue),
+                CostBreakdownRow(label: "recent-model", amountUSD: 3, subtitle: nil, color: .green),
+            ],
+            serviceRows: [],
+            budgetRows: [],
+            cwlWindowDays: 90)
+
+        let monthly = ShareCardData(insights: insights, period: .month)
+
+        #expect(monthly.topModels.map(\.label) == ["recent-model"])
+        #expect(abs((monthly.topModels.first?.cost ?? 0) - 3) < Self.tolerance)
     }
 
     @Test("Share card 30-day period preserves summary-only provider costs")

--- a/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
@@ -229,6 +229,42 @@ struct CostShareServiceTests {
         #expect(abs((monthly.topModels.first?.cost ?? 0) - 3) < Self.tolerance)
     }
 
+    @Test("Share card preserves ledger model mix when provider summaries are missing")
+    func shareCardUsesLedgerModelRowsWhenSummaryBreakdownsAreMissing() {
+        let codex = CostDashboardInsights.ProviderRow(
+            provider: ProviderUsageSnapshot(
+                providerID: "codex",
+                providerName: "Codex",
+                primary: nil,
+                secondary: nil,
+                accountEmail: nil,
+                loginMethod: nil,
+                statusMessage: nil,
+                isError: false,
+                lastUpdated: Date(),
+                costSummary: nil),
+            thirtyDayCost: 10,
+            todayCost: 2,
+            thirtyDayTokens: 1_000,
+            todayTokens: 200,
+            dailyPoints: [self.day(daysAgo: 0, cost: 2, tokens: 200)])
+        let insights = CostDashboardInsights(
+            providerRows: [codex],
+            dailyPoints: [self.day(daysAgo: 0, cost: 2, tokens: 200)],
+            modelRows: [
+                CostBreakdownRow(label: "gpt-5", amountUSD: 7, subtitle: nil, color: .blue),
+                CostBreakdownRow(label: "gpt-5-mini", amountUSD: 3, subtitle: nil, color: .green),
+            ],
+            serviceRows: [],
+            budgetRows: [],
+            cwlWindowDays: 90)
+
+        let monthly = ShareCardData(insights: insights, period: .month)
+
+        #expect(monthly.topModels.map(\.label) == ["gpt-5", "gpt-5-mini"])
+        #expect(abs((monthly.topModels.first?.share ?? 0) - 0.7) < Self.tolerance)
+    }
+
     @Test("Share card 30-day period preserves summary-only provider costs")
     func shareCardMonthPreservesSummaryOnlyProviderCosts() {
         let codex = CostDashboardInsights.ProviderRow(

--- a/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
@@ -265,6 +265,61 @@ struct CostShareServiceTests {
         #expect(abs((monthly.topModels.first?.share ?? 0) - 0.7) < Self.tolerance)
     }
 
+    @Test("Share card preserves ledger model mix when summary and ledger-only providers are mixed")
+    func shareCardUsesLedgerModelRowsForMixedSummaryAndLedgerProviders() {
+        let summaryDay = self.summaryDay(
+            daysAgo: 0,
+            cost: 4,
+            tokens: 400,
+            models: [SyncCostBreakdown(label: "summary-model", costUSD: 4)])
+        let codex = CostDashboardInsights.ProviderRow(
+            provider: self.provider(
+                id: "codex",
+                name: "Codex",
+                daily: [summaryDay]),
+            thirtyDayCost: 4,
+            todayCost: 4,
+            thirtyDayTokens: 400,
+            todayTokens: 400,
+            dailyPoints: [self.day(daysAgo: 0, cost: 4, tokens: 400)])
+        let claude = CostDashboardInsights.ProviderRow(
+            provider: ProviderUsageSnapshot(
+                providerID: "claude",
+                providerName: "Claude",
+                primary: nil,
+                secondary: nil,
+                accountEmail: nil,
+                loginMethod: nil,
+                statusMessage: nil,
+                isError: false,
+                lastUpdated: Date(),
+                costSummary: nil),
+            thirtyDayCost: 6,
+            todayCost: 0,
+            thirtyDayTokens: 600,
+            todayTokens: 0,
+            dailyPoints: [self.day(daysAgo: 1, cost: 6, tokens: 600)])
+        let insights = CostDashboardInsights(
+            providerRows: [codex, claude],
+            dailyPoints: [
+                self.day(daysAgo: 0, cost: 4, tokens: 400),
+                self.day(daysAgo: 1, cost: 6, tokens: 600),
+            ],
+            modelRows: [
+                CostBreakdownRow(label: "ledger-only-model", amountUSD: 6, subtitle: nil, color: .blue),
+                CostBreakdownRow(label: "summary-model", amountUSD: 4, subtitle: nil, color: .green),
+            ],
+            serviceRows: [],
+            budgetRows: [],
+            cwlWindowDays: 90)
+
+        let monthly = ShareCardData(insights: insights, period: .month)
+
+        #expect(monthly.topModels.map(\.label) == ["ledger-only-model", "summary-model"])
+        #expect(abs((monthly.topModels.first?.cost ?? 0) - 6) < Self.tolerance)
+        #expect(abs((monthly.topModels.first?.share ?? 0) - 0.6) < Self.tolerance)
+    }
+
     @Test("Share card 30-day period preserves summary-only provider costs")
     func shareCardMonthPreservesSummaryOnlyProviderCosts() {
         let codex = CostDashboardInsights.ProviderRow(

--- a/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
@@ -36,7 +36,13 @@ struct CostShareServiceTests {
                 historyDays: historyDays))
     }
 
-    private func day(daysAgo: Int, cost: Double, tokens: Int) -> CostDashboardInsights.DailyPoint {
+    private func day(
+        daysAgo: Int,
+        cost: Double,
+        tokens: Int,
+        models: [SyncCostBreakdown] = [],
+        services: [SyncCostBreakdown] = []) -> CostDashboardInsights.DailyPoint
+    {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
         let date = calendar.date(byAdding: .day, value: -daysAgo, to: today)!
@@ -45,7 +51,9 @@ struct CostShareServiceTests {
             dayKey: formatter.string(from: date),
             date: date,
             costUSD: cost,
-            totalTokens: tokens)
+            totalTokens: tokens,
+            modelBreakdowns: models,
+            serviceBreakdowns: services)
     }
 
     private func summaryDay(
@@ -206,14 +214,14 @@ struct CostShareServiceTests {
             thirtyDayTokens: 1_200,
             todayTokens: 300,
             dailyPoints: [
-                self.day(daysAgo: 0, cost: 3, tokens: 300),
-                self.day(daysAgo: 45, cost: 9, tokens: 900),
+                self.day(daysAgo: 0, cost: 3, tokens: 300, models: [recentModel]),
+                self.day(daysAgo: 45, cost: 9, tokens: 900, models: [oldModel]),
             ])
         let insights = CostDashboardInsights(
             providerRows: [codex],
             dailyPoints: [
-                self.day(daysAgo: 0, cost: 3, tokens: 300),
-                self.day(daysAgo: 45, cost: 9, tokens: 900),
+                self.day(daysAgo: 0, cost: 3, tokens: 300, models: [recentModel]),
+                self.day(daysAgo: 45, cost: 9, tokens: 900, models: [oldModel]),
             ],
             modelRows: [
                 CostBreakdownRow(label: "old-model", amountUSD: 9, subtitle: nil, color: .blue),
@@ -231,6 +239,14 @@ struct CostShareServiceTests {
 
     @Test("Share card preserves ledger model mix when provider summaries are missing")
     func shareCardUsesLedgerModelRowsWhenSummaryBreakdownsAreMissing() {
+        let ledgerDay = self.day(
+            daysAgo: 0,
+            cost: 10,
+            tokens: 1_000,
+            models: [
+                SyncCostBreakdown(label: "gpt-5", costUSD: 7),
+                SyncCostBreakdown(label: "gpt-5-mini", costUSD: 3),
+            ])
         let codex = CostDashboardInsights.ProviderRow(
             provider: ProviderUsageSnapshot(
                 providerID: "codex",
@@ -247,10 +263,10 @@ struct CostShareServiceTests {
             todayCost: 2,
             thirtyDayTokens: 1_000,
             todayTokens: 200,
-            dailyPoints: [self.day(daysAgo: 0, cost: 2, tokens: 200)])
+            dailyPoints: [ledgerDay])
         let insights = CostDashboardInsights(
             providerRows: [codex],
-            dailyPoints: [self.day(daysAgo: 0, cost: 2, tokens: 200)],
+            dailyPoints: [ledgerDay],
             modelRows: [
                 CostBreakdownRow(label: "gpt-5", amountUSD: 7, subtitle: nil, color: .blue),
                 CostBreakdownRow(label: "gpt-5-mini", amountUSD: 3, subtitle: nil, color: .green),
@@ -281,7 +297,11 @@ struct CostShareServiceTests {
             todayCost: 4,
             thirtyDayTokens: 400,
             todayTokens: 400,
-            dailyPoints: [self.day(daysAgo: 0, cost: 4, tokens: 400)])
+            dailyPoints: [self.day(
+                daysAgo: 0,
+                cost: 4,
+                tokens: 400,
+                models: [SyncCostBreakdown(label: "summary-model", costUSD: 4)])])
         let claude = CostDashboardInsights.ProviderRow(
             provider: ProviderUsageSnapshot(
                 providerID: "claude",
@@ -298,12 +318,24 @@ struct CostShareServiceTests {
             todayCost: 0,
             thirtyDayTokens: 600,
             todayTokens: 0,
-            dailyPoints: [self.day(daysAgo: 1, cost: 6, tokens: 600)])
+            dailyPoints: [self.day(
+                daysAgo: 1,
+                cost: 6,
+                tokens: 600,
+                models: [SyncCostBreakdown(label: "ledger-only-model", costUSD: 6)])])
         let insights = CostDashboardInsights(
             providerRows: [codex, claude],
             dailyPoints: [
-                self.day(daysAgo: 0, cost: 4, tokens: 400),
-                self.day(daysAgo: 1, cost: 6, tokens: 600),
+                self.day(
+                    daysAgo: 0,
+                    cost: 4,
+                    tokens: 400,
+                    models: [SyncCostBreakdown(label: "summary-model", costUSD: 4)]),
+                self.day(
+                    daysAgo: 1,
+                    cost: 6,
+                    tokens: 600,
+                    models: [SyncCostBreakdown(label: "ledger-only-model", costUSD: 6)]),
             ],
             modelRows: [
                 CostBreakdownRow(label: "ledger-only-model", amountUSD: 6, subtitle: nil, color: .blue),
@@ -318,6 +350,54 @@ struct CostShareServiceTests {
         #expect(monthly.topModels.map(\.label) == ["ledger-only-model", "summary-model"])
         #expect(abs((monthly.topModels.first?.cost ?? 0) - 6) < Self.tolerance)
         #expect(abs((monthly.topModels.first?.share ?? 0) - 0.6) < Self.tolerance)
+    }
+
+    @Test("Share card model mix stays inside the selected period")
+    func shareCardModelMixUsesPeriodScopedDailyBreakdowns() {
+        let recentDay = self.day(
+            daysAgo: 2,
+            cost: 3,
+            tokens: 300,
+            models: [SyncCostBreakdown(label: "recent-model", costUSD: 3)])
+        let oldDay = self.day(
+            daysAgo: 45,
+            cost: 9,
+            tokens: 900,
+            models: [SyncCostBreakdown(label: "old-model", costUSD: 9)])
+        let codex = CostDashboardInsights.ProviderRow(
+            provider: ProviderUsageSnapshot(
+                providerID: "codex",
+                providerName: "Codex",
+                primary: nil,
+                secondary: nil,
+                accountEmail: nil,
+                loginMethod: nil,
+                statusMessage: nil,
+                isError: false,
+                lastUpdated: Date(),
+                costSummary: nil),
+            thirtyDayCost: 12,
+            todayCost: 0,
+            thirtyDayTokens: 1_200,
+            todayTokens: 0,
+            dailyPoints: [recentDay, oldDay])
+        let insights = CostDashboardInsights(
+            providerRows: [codex],
+            dailyPoints: [recentDay, oldDay],
+            modelRows: [
+                CostBreakdownRow(label: "old-model", amountUSD: 9, subtitle: nil, color: .blue),
+                CostBreakdownRow(label: "recent-model", amountUSD: 3, subtitle: nil, color: .green),
+            ],
+            serviceRows: [],
+            budgetRows: [],
+            cwlWindowDays: 90)
+
+        let weekly = ShareCardData(insights: insights, period: .week)
+        let monthly = ShareCardData(insights: insights, period: .month)
+
+        #expect(weekly.topModels.map(\.label) == ["recent-model"])
+        #expect(monthly.topModels.map(\.label) == ["recent-model"])
+        #expect(abs((monthly.topModels.first?.cost ?? 0) - 3) < Self.tolerance)
     }
 
     @Test("Share card summary daily bars include ledger-only provider days")

--- a/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostShareServiceTests.swift
@@ -275,6 +275,45 @@ struct CostShareServiceTests {
         #expect(abs((claudeShare?.share ?? 0) - 0.16) < Self.tolerance)
     }
 
+    @Test("Share card 30-day period uses summary daily bars when local window is shorter")
+    func shareCardMonthUsesSummaryDailyBarsForShorterLedgerWindow() {
+        let summaryDays = (0..<30).map { day in
+            self.summaryDay(
+                daysAgo: day,
+                cost: 1,
+                tokens: 100,
+                models: [])
+        }
+        let codex = CostDashboardInsights.ProviderRow(
+            provider: self.provider(
+                id: "codex",
+                name: "Codex",
+                thirtyDayCost: 30,
+                thirtyDayTokens: 3_000,
+                historyDays: 30,
+                daily: summaryDays),
+            thirtyDayCost: 7,
+            todayCost: 1,
+            thirtyDayTokens: 700,
+            todayTokens: 100,
+            dailyPoints: (0..<7).map { self.day(daysAgo: $0, cost: 1, tokens: 100) })
+        let insights = CostDashboardInsights(
+            providerRows: [codex],
+            dailyPoints: (0..<7).map { self.day(daysAgo: $0, cost: 1, tokens: 100) },
+            modelRows: [],
+            serviceRows: [],
+            budgetRows: [],
+            cwlWindowDays: 7)
+
+        let monthly = ShareCardData(insights: insights, period: .month)
+
+        #expect(abs(monthly.totalCost - 30) < Self.tolerance)
+        #expect(monthly.totalTokens == 3_000)
+        #expect(monthly.activeDays == 30)
+        #expect(monthly.dailyBars.count == 30)
+        #expect(abs(monthly.dailyBars.reduce(0) { $0 + $1.cost } - 30) < Self.tolerance)
+    }
+
     @Test("Share card Today tokens use resolved daily totals, not stale session tokens")
     func shareCardTodayTokensUseResolvedDailyTotals() {
         let codex = CostDashboardInsights.ProviderRow(

--- a/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
@@ -59,6 +59,49 @@ struct CostTabInsightsResolverTests {
         #expect(insights?.total30DayCost == 12)
     }
 
+    @Test("Snapshot insights preserve daily model and service breakdowns")
+    func snapshotInsightsPreserveDailyBreakdowns() throws {
+        let snapshot = SyncedUsageSnapshot(
+            providers: [
+                self.provider(
+                    id: "codex",
+                    name: "Codex",
+                    cost: 8,
+                    tokens: 800,
+                    models: [SyncCostBreakdown(label: "codex-model", costUSD: 8)],
+                    services: [SyncCostBreakdown(label: "codex-run", costUSD: 8)]),
+                self.provider(
+                    id: "claude",
+                    name: "Claude",
+                    cost: 12,
+                    tokens: 1_200,
+                    models: [SyncCostBreakdown(label: "claude-model", costUSD: 12)],
+                    services: [SyncCostBreakdown(label: "claude-api", costUSD: 12)]),
+            ],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+
+        let insights = try #require(CostTabInsightsResolver.make(
+            snapshot: snapshot,
+            ledgerAggregation: nil,
+            isLedgerEnabled: false,
+            isDemoMode: false,
+            localHistoryClearedAt: nil))
+
+        #expect(insights.dailyPoints.count == 1)
+        #expect(Set(insights.dailyPoints[0].modelBreakdowns.map(\.label)) == [
+            "codex-model",
+            "claude-model",
+        ])
+        #expect(insights.dailyPoints[0].modelBreakdowns.reduce(0) { $0 + $1.costUSD } == 20)
+        #expect(Set(insights.dailyPoints[0].serviceBreakdowns.map(\.label)) == [
+            "codex-run",
+            "claude-api",
+        ])
+        #expect(insights.dailyPoints[0].serviceBreakdowns.reduce(0) { $0 + $1.costUSD } == 20)
+    }
+
     @Test("Empty ledger after clear preserves synced budget rows")
     func emptyClearedLedgerPreservesBudgets() {
         let snapshot = SyncedUsageSnapshot(
@@ -193,6 +236,16 @@ struct CostTabInsightsResolverTests {
 
         #expect(insights.total30DayCost == 20)
         #expect(insights.dailyPoints.reduce(0) { $0 + $1.costUSD } == 20)
+        #expect(Set(insights.dailyPoints.flatMap(\.modelBreakdowns).map(\.label)) == [
+            "codex-model",
+            "claude-model",
+        ])
+        #expect(insights.dailyPoints.flatMap(\.modelBreakdowns).reduce(0) { $0 + $1.costUSD } == 20)
+        #expect(Set(insights.dailyPoints.flatMap(\.serviceBreakdowns).map(\.label)) == [
+            "codex-run",
+            "claude-api",
+        ])
+        #expect(insights.dailyPoints.flatMap(\.serviceBreakdowns).reduce(0) { $0 + $1.costUSD } == 20)
         #expect(Set(insights.modelRows.map(\.label)) == ["codex-model", "claude-model"])
         #expect(insights.modelRows.reduce(0) { $0 + $1.amountUSD } == 20)
         #expect(Set(insights.serviceRows.map(\.label)) == ["codex-run", "claude-api"])

--- a/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
@@ -227,6 +227,73 @@ struct CostTabInsightsResolverTests {
         #expect(tomorrow.hasPrefix("2026-07-08|"))
     }
 
+    @Test("Ledger refresh signature changes when provider identities change")
+    func ledgerRefreshSignatureIncludesProviderIdentities() {
+        let codex = ProviderUsageSnapshot(
+            providerID: "codex",
+            providerName: "Codex",
+            primary: nil,
+            secondary: nil,
+            accountEmail: "codex@example.com",
+            loginMethod: nil,
+            statusMessage: nil,
+            isError: false,
+            lastUpdated: self.now,
+            costSummary: SyncCostSummary(
+                sessionCostUSD: nil,
+                sessionTokens: nil,
+                last30DaysCostUSD: 8,
+                last30DaysTokens: 800,
+                daily: [],
+                historyDays: 30))
+        let claude = ProviderUsageSnapshot(
+            providerID: "claude",
+            providerName: "Claude",
+            primary: nil,
+            secondary: nil,
+            accountEmail: "claude@example.com",
+            loginMethod: nil,
+            statusMessage: nil,
+            isError: false,
+            lastUpdated: self.now,
+            costSummary: SyncCostSummary(
+                sessionCostUSD: nil,
+                sessionTokens: nil,
+                last30DaysCostUSD: 8,
+                last30DaysTokens: 800,
+                daily: [],
+                historyDays: 30))
+        let codexSnapshot = SyncedUsageSnapshot(
+            providers: [codex],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+        let claudeSnapshot = SyncedUsageSnapshot(
+            providers: [claude],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+
+        let codexSignature = CostLedgerRefreshSignature.make(
+            isEnabled: true,
+            windowDays: 90,
+            activeDeviceIDs: ["mac-A"],
+            snapshots: [codexSnapshot],
+            clearTombstone: 0,
+            currentDayKey: "2026-07-07")
+        let claudeSignature = CostLedgerRefreshSignature.make(
+            isEnabled: true,
+            windowDays: 90,
+            activeDeviceIDs: ["mac-A"],
+            snapshots: [claudeSnapshot],
+            clearTombstone: 0,
+            currentDayKey: "2026-07-07")
+
+        #expect(codexSignature != claudeSignature)
+        #expect(codexSignature.contains("mac-A:codex|codex@example.com"))
+        #expect(claudeSignature.contains("mac-A:claude|claude@example.com"))
+    }
+
     @Test("Summary-only snapshot after clear can still fill missing ledger provider")
     func freshSummaryOnlySnapshotAfterClearCanFallback() {
         let clearTime = self.now

--- a/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
@@ -19,7 +19,7 @@ struct CostTabInsightsResolverTests {
             ledgerAggregation: self.emptyAggregation(windowDays: 90),
             isLedgerEnabled: true,
             isDemoMode: false,
-            clearedLocalHistory: true)
+            localHistoryClearedAt: self.now.addingTimeInterval(60))
 
         #expect(insights == nil)
     }
@@ -36,7 +36,7 @@ struct CostTabInsightsResolverTests {
             ledgerAggregation: self.emptyAggregation(windowDays: 90),
             isLedgerEnabled: true,
             isDemoMode: false,
-            clearedLocalHistory: false)
+            localHistoryClearedAt: nil)
 
         #expect(insights?.total30DayCost == 12)
     }
@@ -63,7 +63,7 @@ struct CostTabInsightsResolverTests {
             ledgerAggregation: self.emptyAggregation(windowDays: 90),
             isLedgerEnabled: true,
             isDemoMode: false,
-            clearedLocalHistory: true)
+            localHistoryClearedAt: self.now.addingTimeInterval(60))
 
         #expect(insights?.total30DayCost == 0)
         #expect(insights?.providerRows.isEmpty == true)
@@ -119,10 +119,38 @@ struct CostTabInsightsResolverTests {
             ledgerAggregation: aggregation,
             isLedgerEnabled: true,
             isDemoMode: false,
-            clearedLocalHistory: true)
+            localHistoryClearedAt: self.now.addingTimeInterval(60))
 
         #expect(insights?.total30DayCost == 8)
         #expect(insights?.providerRows.map(\.provider.providerID) == ["codex"])
+    }
+
+    @Test("Summary-only snapshot after clear can still fill missing ledger provider")
+    func freshSummaryOnlySnapshotAfterClearCanFallback() {
+        let clearTime = self.now
+        let freshSummaryOnly = self.provider(
+            id: "claude",
+            name: "Claude",
+            cost: 14,
+            tokens: 1_400,
+            lastUpdated: clearTime.addingTimeInterval(60),
+            includeDaily: false)
+        let snapshot = SyncedUsageSnapshot(
+            providers: [freshSummaryOnly],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+
+        let insights = CostTabInsightsResolver.make(
+            snapshot: snapshot,
+            ledgerAggregation: self.emptyAggregation(windowDays: 90),
+            isLedgerEnabled: true,
+            isDemoMode: false,
+            localHistoryClearedAt: clearTime)
+
+        #expect(insights?.total30DayCost == 14)
+        #expect(insights?.providerRows.map(\.provider.providerID) == ["claude"])
+        #expect(insights?.dailyPoints.isEmpty == true)
     }
 
     private func emptyAggregation(windowDays: Int) -> CostLedgerAggregation {
@@ -142,7 +170,9 @@ struct CostTabInsightsResolverTests {
         name: String = "Codex",
         cost: Double,
         tokens: Int,
-        budget: SyncBudgetSnapshot? = nil) -> ProviderUsageSnapshot
+        budget: SyncBudgetSnapshot? = nil,
+        lastUpdated: Date? = nil,
+        includeDaily: Bool = true) -> ProviderUsageSnapshot
     {
         let daily = SyncDailyPoint(
             dayKey: SyncCostSummary.iso8601DayKey(for: self.now),
@@ -160,13 +190,13 @@ struct CostTabInsightsResolverTests {
             loginMethod: nil,
             statusMessage: nil,
             isError: false,
-            lastUpdated: self.now,
+            lastUpdated: lastUpdated ?? self.now,
             costSummary: SyncCostSummary(
                 sessionCostUSD: cost,
                 sessionTokens: tokens,
                 last30DaysCostUSD: cost,
                 last30DaysTokens: tokens,
-                daily: [daily],
+                daily: includeDaily ? [daily] : [],
                 isEstimated: false,
                 historyDays: 30),
             budget: budget)

--- a/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
@@ -143,6 +143,62 @@ struct CostTabInsightsResolverTests {
         #expect(insights?.providerRows.map(\.provider.providerID) == ["codex"])
     }
 
+    @Test("Partial ledger fallback contributes to daily and breakdown aggregates")
+    func partialLedgerFallbackContributesToAllAggregates() throws {
+        let codexDay = self.syncDay(
+            cost: 8,
+            tokens: 800,
+            models: [SyncCostBreakdown(label: "codex-model", costUSD: 8)],
+            services: [SyncCostBreakdown(label: "codex-run", costUSD: 8)])
+        let claude = self.provider(
+            id: "claude",
+            name: "Claude",
+            cost: 12,
+            tokens: 1_200,
+            models: [SyncCostBreakdown(label: "claude-model", costUSD: 12)],
+            services: [SyncCostBreakdown(label: "claude-api", costUSD: 12)])
+        let snapshot = SyncedUsageSnapshot(
+            providers: [
+                self.provider(id: "codex", name: "Codex", cost: 8, tokens: 800),
+                claude,
+            ],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+        let aggregation = CostLedgerAggregation(
+            windowDays: 90,
+            totalCostUSD: 8,
+            totalTokens: 800,
+            activeDayCount: 1,
+            providerRollups: [
+                "codex|_": CostLedgerProviderRollup(
+                    providerID: "codex",
+                    accountEmail: nil,
+                    totalCostUSD: 8,
+                    totalTokens: 800,
+                    dailyPoints: [codexDay],
+                    modelBreakdowns: [SyncCostBreakdown(label: "codex-model", costUSD: 8)],
+                    serviceBreakdowns: [SyncCostBreakdown(label: "codex-run", costUSD: 8)]),
+            ],
+            dailyPoints: [codexDay],
+            modelMix: [SyncCostBreakdown(label: "codex-model", costUSD: 8)],
+            serviceMix: [SyncCostBreakdown(label: "codex-run", costUSD: 8)])
+
+        let insights = try #require(CostTabInsightsResolver.make(
+            snapshot: snapshot,
+            ledgerAggregation: aggregation,
+            isLedgerEnabled: true,
+            isDemoMode: false,
+            localHistoryClearedAt: nil))
+
+        #expect(insights.total30DayCost == 20)
+        #expect(insights.dailyPoints.reduce(0) { $0 + $1.costUSD } == 20)
+        #expect(Set(insights.modelRows.map(\.label)) == ["codex-model", "claude-model"])
+        #expect(insights.modelRows.reduce(0) { $0 + $1.amountUSD } == 20)
+        #expect(Set(insights.serviceRows.map(\.label)) == ["codex-run", "claude-api"])
+        #expect(insights.serviceRows.reduce(0) { $0 + $1.amountUSD } == 20)
+    }
+
     @Test("Summary-only snapshot after clear can still fill missing ledger provider")
     func freshSummaryOnlySnapshotAfterClearCanFallback() {
         let clearTime = self.now
@@ -192,13 +248,34 @@ struct CostTabInsightsResolverTests {
         lastUpdated: Date? = nil,
         includeDaily: Bool = true) -> ProviderUsageSnapshot
     {
-        let daily = SyncDailyPoint(
-            dayKey: SyncCostSummary.iso8601DayKey(for: self.now),
-            costUSD: cost,
-            totalTokens: tokens,
-            modelBreakdowns: [],
-            serviceBreakdowns: [],
-            isEstimated: false)
+        self.provider(
+            id: id,
+            name: name,
+            cost: cost,
+            tokens: tokens,
+            budget: budget,
+            lastUpdated: lastUpdated,
+            includeDaily: includeDaily,
+            models: [],
+            services: [])
+    }
+
+    private func provider(
+        id: String,
+        name: String,
+        cost: Double,
+        tokens: Int,
+        budget: SyncBudgetSnapshot? = nil,
+        lastUpdated: Date? = nil,
+        includeDaily: Bool = true,
+        models: [SyncCostBreakdown],
+        services: [SyncCostBreakdown]) -> ProviderUsageSnapshot
+    {
+        let daily = self.syncDay(
+            cost: cost,
+            tokens: tokens,
+            models: models,
+            services: services)
         return ProviderUsageSnapshot(
             providerID: id,
             providerName: name,
@@ -218,5 +295,20 @@ struct CostTabInsightsResolverTests {
                 isEstimated: false,
                 historyDays: 30),
             budget: budget)
+    }
+
+    private func syncDay(
+        cost: Double,
+        tokens: Int,
+        models: [SyncCostBreakdown],
+        services: [SyncCostBreakdown]) -> SyncDailyPoint
+    {
+        SyncDailyPoint(
+            dayKey: SyncCostSummary.iso8601DayKey(for: self.now),
+            costUSD: cost,
+            totalTokens: tokens,
+            modelBreakdowns: models,
+            serviceBreakdowns: services,
+            isEstimated: false)
     }
 }

--- a/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
@@ -24,6 +24,24 @@ struct CostTabInsightsResolverTests {
         #expect(insights == nil)
     }
 
+    @Test("Missing ledger after clear does not fall back to stale synced cost summary")
+    func missingClearedLedgerStaysEmpty() {
+        let snapshot = SyncedUsageSnapshot(
+            providers: [self.provider(cost: 12, tokens: 1_200)],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+        let insights = CostTabInsightsResolver.make(
+            snapshot: snapshot,
+            ledgerAggregation: nil,
+            isLedgerEnabled: true,
+            isDemoMode: false,
+            localHistoryClearedAt: self.now.addingTimeInterval(60),
+            ledgerWindowDays: 90)
+
+        #expect(insights == nil)
+    }
+
     @Test("Empty ledger without clear falls back to synced snapshot")
     func emptyUnclearedLedgerFallsBackToSnapshot() {
         let snapshot = SyncedUsageSnapshot(

--- a/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
@@ -41,6 +41,61 @@ struct CostTabInsightsResolverTests {
         #expect(insights?.total30DayCost == 12)
     }
 
+    @Test("Partial ledger after clear does not append missing providers from stale snapshots")
+    func partialClearedLedgerDoesNotAppendMissingSnapshotProviders() {
+        let refreshed = self.provider(id: "codex", name: "Codex", cost: 8, tokens: 800)
+        let stale = self.provider(id: "claude", name: "Claude", cost: 12, tokens: 1_200)
+        let snapshot = SyncedUsageSnapshot(
+            providers: [refreshed, stale],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+        let aggregation = CostLedgerAggregation(
+            windowDays: 90,
+            totalCostUSD: 8,
+            totalTokens: 800,
+            activeDayCount: 1,
+            providerRollups: [
+                "codex|_": CostLedgerProviderRollup(
+                    providerID: "codex",
+                    accountEmail: nil,
+                    totalCostUSD: 8,
+                    totalTokens: 800,
+                    dailyPoints: [
+                        SyncDailyPoint(
+                            dayKey: SyncCostSummary.iso8601DayKey(for: self.now),
+                            costUSD: 8,
+                            totalTokens: 800,
+                            modelBreakdowns: [],
+                            serviceBreakdowns: [],
+                            isEstimated: false),
+                    ],
+                    modelBreakdowns: [],
+                    serviceBreakdowns: []),
+            ],
+            dailyPoints: [
+                SyncDailyPoint(
+                    dayKey: SyncCostSummary.iso8601DayKey(for: self.now),
+                    costUSD: 8,
+                    totalTokens: 800,
+                    modelBreakdowns: [],
+                    serviceBreakdowns: [],
+                    isEstimated: false),
+            ],
+            modelMix: [],
+            serviceMix: [])
+
+        let insights = CostTabInsightsResolver.make(
+            snapshot: snapshot,
+            ledgerAggregation: aggregation,
+            isLedgerEnabled: true,
+            isDemoMode: false,
+            clearedLocalHistory: true)
+
+        #expect(insights?.total30DayCost == 8)
+        #expect(insights?.providerRows.map(\.provider.providerID) == ["codex"])
+    }
+
     private func emptyAggregation(windowDays: Int) -> CostLedgerAggregation {
         CostLedgerAggregation(
             windowDays: windowDays,
@@ -53,7 +108,12 @@ struct CostTabInsightsResolverTests {
             serviceMix: [])
     }
 
-    private func provider(cost: Double, tokens: Int) -> ProviderUsageSnapshot {
+    private func provider(
+        id: String = "codex",
+        name: String = "Codex",
+        cost: Double,
+        tokens: Int) -> ProviderUsageSnapshot
+    {
         let daily = SyncDailyPoint(
             dayKey: SyncCostSummary.iso8601DayKey(for: self.now),
             costUSD: cost,
@@ -62,8 +122,8 @@ struct CostTabInsightsResolverTests {
             serviceBreakdowns: [],
             isEstimated: false)
         return ProviderUsageSnapshot(
-            providerID: "codex",
-            providerName: "Codex",
+            providerID: id,
+            providerName: name,
             primary: nil,
             secondary: nil,
             accountEmail: nil,

--- a/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
@@ -199,6 +199,34 @@ struct CostTabInsightsResolverTests {
         #expect(insights.serviceRows.reduce(0) { $0 + $1.amountUSD } == 20)
     }
 
+    @Test("Ledger refresh signature changes when the local day changes")
+    func ledgerRefreshSignatureIncludesCurrentDay() {
+        let snapshot = SyncedUsageSnapshot(
+            providers: [self.provider(cost: 8, tokens: 800)],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+
+        let today = CostLedgerRefreshSignature.make(
+            isEnabled: true,
+            windowDays: 90,
+            activeDeviceIDs: ["mac-A"],
+            snapshots: [snapshot],
+            clearTombstone: 0,
+            currentDayKey: "2026-07-07")
+        let tomorrow = CostLedgerRefreshSignature.make(
+            isEnabled: true,
+            windowDays: 90,
+            activeDeviceIDs: ["mac-A"],
+            snapshots: [snapshot],
+            clearTombstone: 0,
+            currentDayKey: "2026-07-08")
+
+        #expect(today != tomorrow)
+        #expect(today.hasPrefix("2026-07-07|"))
+        #expect(tomorrow.hasPrefix("2026-07-08|"))
+    }
+
     @Test("Summary-only snapshot after clear can still fill missing ledger provider")
     func freshSummaryOnlySnapshotAfterClearCanFallback() {
         let clearTime = self.now

--- a/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
@@ -1,0 +1,83 @@
+import CodexBarSync
+import Foundation
+import Testing
+@testable import CodexBarMobile
+
+@Suite("Cost tab insight resolver")
+struct CostTabInsightsResolverTests {
+    private let now = Date()
+
+    @Test("Empty ledger after clear does not fall back to stale synced cost summary")
+    func emptyClearedLedgerStaysEmpty() {
+        let snapshot = SyncedUsageSnapshot(
+            providers: [self.provider(cost: 12, tokens: 1_200)],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+        let insights = CostTabInsightsResolver.make(
+            snapshot: snapshot,
+            ledgerAggregation: self.emptyAggregation(windowDays: 90),
+            isLedgerEnabled: true,
+            isDemoMode: false,
+            clearedLocalHistory: true)
+
+        #expect(insights == nil)
+    }
+
+    @Test("Empty ledger without clear falls back to synced snapshot")
+    func emptyUnclearedLedgerFallsBackToSnapshot() {
+        let snapshot = SyncedUsageSnapshot(
+            providers: [self.provider(cost: 12, tokens: 1_200)],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+        let insights = CostTabInsightsResolver.make(
+            snapshot: snapshot,
+            ledgerAggregation: self.emptyAggregation(windowDays: 90),
+            isLedgerEnabled: true,
+            isDemoMode: false,
+            clearedLocalHistory: false)
+
+        #expect(insights?.total30DayCost == 12)
+    }
+
+    private func emptyAggregation(windowDays: Int) -> CostLedgerAggregation {
+        CostLedgerAggregation(
+            windowDays: windowDays,
+            totalCostUSD: 0,
+            totalTokens: 0,
+            activeDayCount: 0,
+            providerRollups: [:],
+            dailyPoints: [],
+            modelMix: [],
+            serviceMix: [])
+    }
+
+    private func provider(cost: Double, tokens: Int) -> ProviderUsageSnapshot {
+        let daily = SyncDailyPoint(
+            dayKey: SyncCostSummary.iso8601DayKey(for: self.now),
+            costUSD: cost,
+            totalTokens: tokens,
+            modelBreakdowns: [],
+            serviceBreakdowns: [],
+            isEstimated: false)
+        return ProviderUsageSnapshot(
+            providerID: "codex",
+            providerName: "Codex",
+            primary: nil,
+            secondary: nil,
+            accountEmail: nil,
+            loginMethod: nil,
+            statusMessage: nil,
+            isError: false,
+            lastUpdated: self.now,
+            costSummary: SyncCostSummary(
+                sessionCostUSD: cost,
+                sessionTokens: tokens,
+                last30DaysCostUSD: cost,
+                last30DaysTokens: tokens,
+                daily: [daily],
+                isEstimated: false,
+                historyDays: 30))
+    }
+}

--- a/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
@@ -41,6 +41,35 @@ struct CostTabInsightsResolverTests {
         #expect(insights?.total30DayCost == 12)
     }
 
+    @Test("Empty ledger after clear preserves synced budget rows")
+    func emptyClearedLedgerPreservesBudgets() {
+        let snapshot = SyncedUsageSnapshot(
+            providers: [
+                self.provider(
+                    cost: 12,
+                    tokens: 1_200,
+                    budget: SyncBudgetSnapshot(
+                        usedAmount: 40,
+                        limitAmount: 100,
+                        currencyCode: "USD",
+                        period: "Monthly",
+                        resetsAt: nil)),
+            ],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+        let insights = CostTabInsightsResolver.make(
+            snapshot: snapshot,
+            ledgerAggregation: self.emptyAggregation(windowDays: 90),
+            isLedgerEnabled: true,
+            isDemoMode: false,
+            clearedLocalHistory: true)
+
+        #expect(insights?.total30DayCost == 0)
+        #expect(insights?.providerRows.isEmpty == true)
+        #expect(insights?.budgetRows.count == 1)
+    }
+
     @Test("Partial ledger after clear does not append missing providers from stale snapshots")
     func partialClearedLedgerDoesNotAppendMissingSnapshotProviders() {
         let refreshed = self.provider(id: "codex", name: "Codex", cost: 8, tokens: 800)
@@ -112,7 +141,8 @@ struct CostTabInsightsResolverTests {
         id: String = "codex",
         name: String = "Codex",
         cost: Double,
-        tokens: Int) -> ProviderUsageSnapshot
+        tokens: Int,
+        budget: SyncBudgetSnapshot? = nil) -> ProviderUsageSnapshot
     {
         let daily = SyncDailyPoint(
             dayKey: SyncCostSummary.iso8601DayKey(for: self.now),
@@ -138,6 +168,7 @@ struct CostTabInsightsResolverTests {
                 last30DaysTokens: tokens,
                 daily: [daily],
                 isEstimated: false,
-                historyDays: 30))
+                historyDays: 30),
+            budget: budget)
     }
 }

--- a/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/CostTabInsightsResolverTests.swift
@@ -252,6 +252,72 @@ struct CostTabInsightsResolverTests {
         #expect(insights.serviceRows.reduce(0) { $0 + $1.amountUSD } == 20)
     }
 
+    @Test("Short ledger windows count missing-provider daily fallback totals")
+    func shortLedgerWindowCountsMissingProviderDailyFallback() throws {
+        let codexDay = self.syncDay(
+            daysAgo: 0,
+            cost: 2,
+            tokens: 200,
+            models: [SyncCostBreakdown(label: "codex-model", costUSD: 2)],
+            services: [])
+        let claudeRecentDay = self.syncDay(
+            daysAgo: 1,
+            cost: 6,
+            tokens: 600,
+            models: [SyncCostBreakdown(label: "claude-recent", costUSD: 6)],
+            services: [])
+        let claudeOldDay = self.syncDay(
+            daysAgo: 10,
+            cost: 10,
+            tokens: 1_000,
+            models: [SyncCostBreakdown(label: "claude-old", costUSD: 10)],
+            services: [])
+        let snapshot = SyncedUsageSnapshot(
+            providers: [
+                self.provider(id: "codex", name: "Codex", cost: 2, tokens: 200),
+                self.provider(
+                    id: "claude",
+                    name: "Claude",
+                    cost: 16,
+                    tokens: 1_600,
+                    daily: [claudeRecentDay, claudeOldDay]),
+            ],
+            syncTimestamp: self.now,
+            deviceName: "Mac",
+            deviceID: "mac-A")
+        let aggregation = CostLedgerAggregation(
+            windowDays: 7,
+            totalCostUSD: 2,
+            totalTokens: 200,
+            activeDayCount: 1,
+            providerRollups: [
+                "codex|_": CostLedgerProviderRollup(
+                    providerID: "codex",
+                    accountEmail: nil,
+                    totalCostUSD: 2,
+                    totalTokens: 200,
+                    dailyPoints: [codexDay],
+                    modelBreakdowns: codexDay.modelBreakdowns,
+                    serviceBreakdowns: []),
+            ],
+            dailyPoints: [codexDay],
+            modelMix: codexDay.modelBreakdowns,
+            serviceMix: [])
+
+        let insights = try #require(CostTabInsightsResolver.make(
+            snapshot: snapshot,
+            ledgerAggregation: aggregation,
+            isLedgerEnabled: true,
+            isDemoMode: false,
+            localHistoryClearedAt: nil))
+
+        #expect(insights.total30DayCost == 8)
+        #expect(insights.total30DayTokens == 800)
+        #expect(insights.providerRows.first(where: { $0.provider.providerID == "claude" })?.thirtyDayCost == 6)
+        #expect(insights.dailyPoints.reduce(0) { $0 + $1.costUSD } == 8)
+        #expect(Set(insights.modelRows.map(\.label)) == ["codex-model", "claude-recent"])
+    }
+
     @Test("Ledger refresh signature changes when the local day changes")
     func ledgerRefreshSignatureIncludesCurrentDay() {
         let snapshot = SyncedUsageSnapshot(
@@ -413,6 +479,33 @@ struct CostTabInsightsResolverTests {
         name: String,
         cost: Double,
         tokens: Int,
+        daily: [SyncDailyPoint]) -> ProviderUsageSnapshot
+    {
+        ProviderUsageSnapshot(
+            providerID: id,
+            providerName: name,
+            primary: nil,
+            secondary: nil,
+            accountEmail: nil,
+            loginMethod: nil,
+            statusMessage: nil,
+            isError: false,
+            lastUpdated: self.now,
+            costSummary: SyncCostSummary(
+                sessionCostUSD: nil,
+                sessionTokens: nil,
+                last30DaysCostUSD: cost,
+                last30DaysTokens: tokens,
+                daily: daily,
+                isEstimated: false,
+                historyDays: 30))
+    }
+
+    private func provider(
+        id: String,
+        name: String,
+        cost: Double,
+        tokens: Int,
         budget: SyncBudgetSnapshot? = nil,
         lastUpdated: Date? = nil,
         includeDaily: Bool = true,
@@ -446,13 +539,15 @@ struct CostTabInsightsResolverTests {
     }
 
     private func syncDay(
+        daysAgo: Int = 0,
         cost: Double,
         tokens: Int,
         models: [SyncCostBreakdown],
         services: [SyncCostBreakdown]) -> SyncDailyPoint
     {
-        SyncDailyPoint(
-            dayKey: SyncCostSummary.iso8601DayKey(for: self.now),
+        let date = Calendar.current.date(byAdding: .day, value: -daysAgo, to: self.now) ?? self.now
+        return SyncDailyPoint(
+            dayKey: SyncCostSummary.iso8601DayKey(for: date),
             costUSD: cost,
             totalTokens: tokens,
             modelBreakdowns: models,

--- a/CodexBarMobile/CodexBarMobileTests/DeviceLifecycleEventTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/DeviceLifecycleEventTests.swift
@@ -78,14 +78,18 @@ struct DeviceLifecycleEventTests {
         let oldMac = Self.makeMac(deviceID: "old", deviceName: "Pixel's Mac", cost: 1, timestamp: 100)
         let newMac = Self.makeMac(deviceID: "new", deviceName: "Pixel's Mac", cost: 2, timestamp: 200)
         let alias = DeviceLifecycleEvent(
+            recordID: "alias-old-new",
             kind: .alias,
             primaryDeviceID: "new",
             relatedDeviceIDs: ["old"],
+            confirmedAt: Date(timeIntervalSince1970: 100),
             confirmedFromDeviceID: "iphone-a")
         let unalias = DeviceLifecycleEvent(
+            recordID: "unalias-old-new",
             kind: .unalias,
             primaryDeviceID: "old",
             relatedDeviceIDs: ["new"],
+            confirmedAt: Date(timeIntervalSince1970: 200),
             confirmedFromDeviceID: "iphone-a")
 
         let resolved = CloudSyncReader.resolveDeviceSnapshots(

--- a/CodexBarMobile/CodexBarMobileTests/SnapshotCacheTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/SnapshotCacheTests.swift
@@ -134,6 +134,25 @@ struct SnapshotCacheTests {
         #expect(cache.deviceMetadata["mac-A"] != nil)
     }
 
+    @Test("Incremental persistence payload filters deleted providers from legacy fallback")
+    func incrementalPersistenceFiltersDeletedProviderFromLegacyFallback() {
+        let legacyFallback = snapshot(
+            deviceID: "mac-A",
+            deviceName: "Mac A",
+            providers: [
+                provider(id: "codex", lastUpdated: t1),
+                provider(id: "claude", lastUpdated: t1),
+            ],
+            timestamp: t1)
+
+        let filtered = SyncedUsageData.snapshotsFilteringDeletedProvidersForIncrementalPersistence(
+            [legacyFallback],
+            deletedRecordNames: ["mac-A|codex|_"])
+
+        #expect(filtered.count == 1)
+        #expect(filtered[0].providers.map(\.providerID) == ["claude"])
+    }
+
     // MARK: - Priority merge
 
     @Test("Device in per-provider bucket wins over legacy bucket")

--- a/CodexBarMobile/CodexBarMobileTests/Storage/CWLAggregateTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/CWLAggregateTests.swift
@@ -38,19 +38,21 @@ struct CWLAggregateTests {
         return (url, ModelContext(container))
     }
 
-    /// Fixed "today" so window math is deterministic regardless of when
-    /// the test runs. Built from explicit components instead of a magic
+    /// Fixed local "today" so window math is deterministic regardless of
+    /// when the test runs. Built from explicit components instead of a magic
     /// timestamp — easier to verify by eye.
     private static let asOf: Date = {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(identifier: "UTC")!
+        calendar.timeZone = .current
         return calendar.date(
-            from: DateComponents(year: 2026, month: 5, day: 28))!
+            from: DateComponents(year: 2026, month: 5, day: 28, hour: 12))!
     }()
 
     private func dayKey(daysAgo: Int) -> String {
-        let d = Self.asOf.addingTimeInterval(-TimeInterval(daysAgo * 86400))
-        return CostLedgerService.utcDayKeyFormatter.string(from: d)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .current
+        let d = calendar.date(byAdding: .day, value: -daysAgo, to: Self.asOf) ?? Self.asOf
+        return SyncCostSummary.iso8601DayKeyFormatter().string(from: d)
     }
 
     private func insert(
@@ -355,11 +357,26 @@ struct CWLAggregateTests {
 
     @Test("T6: cutoffDayKey — windowDays=1 → today; windowDays=7 → today-6")
     func testCutoffDayKey() {
-        // 2026-05-28 UTC
+        // 2026-05-28 local time
         let asOf = Self.asOf
         #expect(CostLedgerService.cutoffDayKey(windowDays: 1, asOf: asOf) == "2026-05-28")
         #expect(CostLedgerService.cutoffDayKey(windowDays: 7, asOf: asOf) == "2026-05-22")
         #expect(CostLedgerService.cutoffDayKey(windowDays: 30, asOf: asOf) == "2026-04-29")
+    }
+
+    @Test("T6: cutoffDayKey follows local day when UTC has advanced")
+    func testCutoffDayKeyUsesLocalTimezone() throws {
+        let previousDefault = NSTimeZone.default
+        NSTimeZone.default = try #require(TimeZone(identifier: "America/Los_Angeles"))
+        defer { NSTimeZone.default = previousDefault }
+
+        var utcCalendar = Calendar(identifier: .gregorian)
+        utcCalendar.timeZone = TimeZone(identifier: "UTC")!
+        let utcNextDay = try #require(utcCalendar.date(
+            from: DateComponents(year: 2026, month: 5, day: 29, hour: 0, minute: 30)))
+
+        #expect(CostLedgerService.cutoffDayKey(windowDays: 1, asOf: utcNextDay) == "2026-05-28")
+        #expect(CostLedgerService.cutoffDayKey(windowDays: 7, asOf: utcNextDay) == "2026-05-22")
     }
 
     // MARK: - aggregateProvider

--- a/CodexBarMobile/CodexBarMobileTests/Storage/CWLAggregateTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/CWLAggregateTests.swift
@@ -479,6 +479,10 @@ struct CWLAggregateTests {
         defer { ModelContainerFactory.deleteStoreFiles(at: url) }
 
         let t = Date(timeIntervalSince1970: 1_700_000_000)
+        let suiteName = "CodexBarTests-CWLClear-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
         try self.insert(context, device: "dev-A", provider: "codex",
             daysAgo: 0, cost: 1.0, tokens: 100, lastUpdated: t)
         try self.insert(context, device: "dev-A", provider: "claude",
@@ -489,11 +493,12 @@ struct CWLAggregateTests {
         try context.save()
         #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).count == 2)
 
-        try CostLedgerService.clearAll(in: context)
+        try CostLedgerService.clearAll(in: context, clearedAt: t, userDefaults: defaults)
 
         #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).isEmpty,
             "ledger must be empty after clearAll")
         #expect(try context.fetch(FetchDescriptor<DeviceRecord>()).count == 1,
             "clearAll must only delete DailyCostPoint, not other entities")
+        #expect(defaults.double(forKey: MobileSettingsKeys.cwlBlobSeedClearedAt) == t.timeIntervalSince1970)
     }
 }

--- a/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
@@ -143,6 +143,13 @@ struct CWLSeedTests {
             in: context)
         context.insert(ProviderSnapshotModel(
             deviceID: "dev-A",
+            providerID: "codex",
+            providerName: "Codex",
+            accountEmail: nil,
+            lastUpdated: asOf,
+            costSummaryData: nil))
+        context.insert(ProviderSnapshotModel(
+            deviceID: "dev-A",
             providerID: "claude",
             providerName: "Claude",
             accountEmail: nil,
@@ -159,6 +166,55 @@ struct CWLSeedTests {
         #expect(aggregation.providerRollups["codex|_"]?.totalCostUSD == 5.0)
         #expect(aggregation.providerRollups["claude|_"]?.totalCostUSD == 6.0)
         #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).count == 2)
+    }
+
+    @Test("T10: default-on aggregate prunes ledger rows for removed provider snapshots")
+    func testDefaultOnAggregatePrunesRemovedProviderRows() throws {
+        let (url, context) = self.makeContext()
+        defer { ModelContainerFactory.deleteStoreFiles(at: url) }
+
+        let asOf = try #require(CostLedgerService.utcDayKeyFormatter.date(from: "2026-05-28"))
+        try CostLedgerService.upsertDayPoint(
+            deviceID: "dev-A",
+            providerID: "codex",
+            dayKey: "2026-05-28",
+            costUSD: 5.0,
+            totalTokens: 500,
+            isEstimated: false,
+            modelBreakdowns: [],
+            serviceBreakdowns: [],
+            lastUpdated: asOf,
+            in: context)
+        try CostLedgerService.upsertDayPoint(
+            deviceID: "dev-A",
+            providerID: "claude",
+            dayKey: "2026-05-28",
+            costUSD: 6.0,
+            totalTokens: 600,
+            isEstimated: false,
+            modelBreakdowns: [],
+            serviceBreakdowns: [],
+            lastUpdated: asOf,
+            in: context)
+        context.insert(ProviderSnapshotModel(
+            deviceID: "dev-A",
+            providerID: "codex",
+            providerName: "Codex",
+            accountEmail: nil,
+            lastUpdated: asOf,
+            costSummaryData: nil))
+        try context.save()
+
+        let aggregation = try CostLedgerService.aggregateSeedingFromExistingBlobsIfNeeded(
+            windowDays: 90,
+            in: context,
+            asOf: asOf)
+
+        let rows = try context.fetch(FetchDescriptor<DailyCostPoint>())
+        #expect(aggregation.totalCostUSD == 5.0)
+        #expect(aggregation.providerRollups["codex|_"]?.totalCostUSD == 5.0)
+        #expect(aggregation.providerRollups["claude|_"] == nil)
+        #expect(rows.map(\.providerID) == ["codex"])
     }
 
     @Test("T10: default-on aggregate does not reseed blobs older than explicit clear")

--- a/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
@@ -96,6 +96,34 @@ struct CWLSeedTests {
         #expect(rows.first?.costUSD == 5.0)
     }
 
+    @Test("T10: default-on aggregate seeds existing blobs before first ledger read")
+    func testDefaultOnAggregateSeedsBeforeRead() throws {
+        let (url, context) = self.makeContext()
+        defer { ModelContainerFactory.deleteStoreFiles(at: url) }
+
+        let asOf = try #require(CostLedgerService.utcDayKeyFormatter.date(from: "2026-05-28"))
+        context.insert(ProviderSnapshotModel(
+            deviceID: "dev-A",
+            providerID: "codex",
+            providerName: "Codex",
+            accountEmail: nil,
+            lastUpdated: asOf,
+            costSummaryData: self.summaryBlob(daily: [self.day("2026-05-28", 5.0, 500)])))
+        try context.save()
+
+        #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).isEmpty)
+
+        let aggregation = try CostLedgerService.aggregateSeedingFromExistingBlobsIfNeeded(
+            windowDays: 90,
+            in: context,
+            asOf: asOf)
+
+        #expect(aggregation.totalCostUSD == 5.0)
+        #expect(aggregation.totalTokens == 500)
+        #expect(aggregation.providerRollups["codex|_"]?.totalCostUSD == 5.0)
+        #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).count == 1)
+    }
+
     // MARK: - T11
 
     @Test("T11: corrupt blob is skipped, valid rows still seed, no crash")

--- a/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
@@ -101,7 +101,7 @@ struct CWLSeedTests {
         let (url, context) = self.makeContext()
         defer { ModelContainerFactory.deleteStoreFiles(at: url) }
 
-        let asOf = try #require(CostLedgerService.utcDayKeyFormatter.date(from: "2026-05-28"))
+        let asOf = try #require(SyncCostSummary.iso8601DayKeyFormatter().date(from: "2026-05-28"))
         context.insert(ProviderSnapshotModel(
             deviceID: "dev-A",
             providerID: "codex",
@@ -129,7 +129,7 @@ struct CWLSeedTests {
         let (url, context) = self.makeContext()
         defer { ModelContainerFactory.deleteStoreFiles(at: url) }
 
-        let asOf = try #require(CostLedgerService.utcDayKeyFormatter.date(from: "2026-05-28"))
+        let asOf = try #require(SyncCostSummary.iso8601DayKeyFormatter().date(from: "2026-05-28"))
         try CostLedgerService.upsertDayPoint(
             deviceID: "dev-A",
             providerID: "codex",
@@ -173,7 +173,7 @@ struct CWLSeedTests {
         let (url, context) = self.makeContext()
         defer { ModelContainerFactory.deleteStoreFiles(at: url) }
 
-        let asOf = try #require(CostLedgerService.utcDayKeyFormatter.date(from: "2026-05-28"))
+        let asOf = try #require(SyncCostSummary.iso8601DayKeyFormatter().date(from: "2026-05-28"))
         try CostLedgerService.upsertDayPoint(
             deviceID: "dev-A",
             providerID: "codex",
@@ -222,7 +222,7 @@ struct CWLSeedTests {
         let (url, context) = self.makeContext()
         defer { ModelContainerFactory.deleteStoreFiles(at: url) }
 
-        let asOf = try #require(CostLedgerService.utcDayKeyFormatter.date(from: "2026-05-28"))
+        let asOf = try #require(SyncCostSummary.iso8601DayKeyFormatter().date(from: "2026-05-28"))
         try CostLedgerService.upsertDayPoint(
             deviceID: "dev-A",
             providerID: "claude",
@@ -255,7 +255,7 @@ struct CWLSeedTests {
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        let asOf = try #require(CostLedgerService.utcDayKeyFormatter.date(from: "2026-05-28"))
+        let asOf = try #require(SyncCostSummary.iso8601DayKeyFormatter().date(from: "2026-05-28"))
         let clearedAt = asOf.addingTimeInterval(60)
         context.insert(ProviderSnapshotModel(
             deviceID: "dev-A",

--- a/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
@@ -124,6 +124,60 @@ struct CWLSeedTests {
         #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).count == 1)
     }
 
+    @Test("T10: default-on aggregate does not reseed blobs older than explicit clear")
+    func testDefaultOnAggregateHonorsClearTombstone() throws {
+        let (url, context) = self.makeContext()
+        defer { ModelContainerFactory.deleteStoreFiles(at: url) }
+
+        let suiteName = "CodexBarTests-CWLSeed-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let asOf = try #require(CostLedgerService.utcDayKeyFormatter.date(from: "2026-05-28"))
+        let clearedAt = asOf.addingTimeInterval(60)
+        context.insert(ProviderSnapshotModel(
+            deviceID: "dev-A",
+            providerID: "codex",
+            providerName: "Codex",
+            accountEmail: nil,
+            lastUpdated: asOf,
+            costSummaryData: self.summaryBlob(daily: [self.day("2026-05-28", 5.0, 500)])))
+        try context.save()
+
+        try CostLedgerService.seedFromExistingBlobs(in: context)
+        #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).count == 1)
+
+        try CostLedgerService.clearAll(in: context, clearedAt: clearedAt, userDefaults: defaults)
+
+        let clearedAggregation = try CostLedgerService.aggregateSeedingFromExistingBlobsIfNeeded(
+            windowDays: 90,
+            in: context,
+            asOf: asOf,
+            userDefaults: defaults)
+
+        #expect(clearedAggregation.totalCostUSD == 0)
+        #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).isEmpty)
+
+        context.insert(ProviderSnapshotModel(
+            deviceID: "dev-A",
+            providerID: "claude",
+            providerName: "Claude",
+            accountEmail: nil,
+            lastUpdated: clearedAt.addingTimeInterval(60),
+            costSummaryData: self.summaryBlob(daily: [self.day("2026-05-28", 6.0, 600)])))
+        try context.save()
+
+        let refreshedAggregation = try CostLedgerService.aggregateSeedingFromExistingBlobsIfNeeded(
+            windowDays: 90,
+            in: context,
+            asOf: asOf,
+            userDefaults: defaults)
+
+        #expect(refreshedAggregation.totalCostUSD == 6.0)
+        #expect(refreshedAggregation.providerRollups["claude|_"]?.totalCostUSD == 6.0)
+        #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).count == 1)
+    }
+
     // MARK: - T11
 
     @Test("T11: corrupt blob is skipped, valid rows still seed, no crash")

--- a/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
@@ -178,6 +178,49 @@ struct CWLSeedTests {
         #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).count == 1)
     }
 
+    @Test("T10: re-enable seed preserves clear tombstone and imports only newer blobs")
+    func testReEnableSeedPreservesClearTombstone() throws {
+        let (url, context) = self.makeContext()
+        defer { ModelContainerFactory.deleteStoreFiles(at: url) }
+
+        let suiteName = "CodexBarTests-CWLSeed-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let oldSync = Date(timeIntervalSince1970: 1_700_000_000)
+        let clearedAt = oldSync.addingTimeInterval(60)
+        let newSync = clearedAt.addingTimeInterval(60)
+        defaults.set(
+            clearedAt.timeIntervalSince1970,
+            forKey: MobileSettingsKeys.cwlBlobSeedClearedAt)
+
+        context.insert(ProviderSnapshotModel(
+            deviceID: "dev-A",
+            providerID: "codex",
+            providerName: "Codex",
+            accountEmail: nil,
+            lastUpdated: oldSync,
+            costSummaryData: self.summaryBlob(daily: [self.day("2026-05-28", 5.0, 500)])))
+        context.insert(ProviderSnapshotModel(
+            deviceID: "dev-A",
+            providerID: "claude",
+            providerName: "Claude",
+            accountEmail: nil,
+            lastUpdated: newSync,
+            costSummaryData: self.summaryBlob(daily: [self.day("2026-05-28", 6.0, 600)])))
+        try context.save()
+
+        try CostLedgerService.seedFromExistingBlobsRespectingClearTombstone(
+            in: context,
+            userDefaults: defaults)
+
+        let rows = try context.fetch(FetchDescriptor<DailyCostPoint>())
+        #expect(rows.count == 1)
+        #expect(rows.first?.providerID == "claude")
+        #expect(rows.first?.costUSD == 6.0)
+        #expect(defaults.double(forKey: MobileSettingsKeys.cwlBlobSeedClearedAt) == clearedAt.timeIntervalSince1970)
+    }
+
     // MARK: - T11
 
     @Test("T11: corrupt blob is skipped, valid rows still seed, no crash")

--- a/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
@@ -217,6 +217,35 @@ struct CWLSeedTests {
         #expect(rows.map(\.providerID) == ["codex"])
     }
 
+    @Test("T10: default-on aggregate prunes ledger rows when no provider snapshots remain")
+    func testDefaultOnAggregatePrunesRowsWhenLastProviderRemoved() throws {
+        let (url, context) = self.makeContext()
+        defer { ModelContainerFactory.deleteStoreFiles(at: url) }
+
+        let asOf = try #require(CostLedgerService.utcDayKeyFormatter.date(from: "2026-05-28"))
+        try CostLedgerService.upsertDayPoint(
+            deviceID: "dev-A",
+            providerID: "claude",
+            dayKey: "2026-05-28",
+            costUSD: 6.0,
+            totalTokens: 600,
+            isEstimated: false,
+            modelBreakdowns: [],
+            serviceBreakdowns: [],
+            lastUpdated: asOf,
+            in: context)
+        try context.save()
+
+        let aggregation = try CostLedgerService.aggregateSeedingFromExistingBlobsIfNeeded(
+            windowDays: 90,
+            in: context,
+            asOf: asOf)
+
+        #expect(aggregation.totalCostUSD == 0)
+        #expect(aggregation.providerRollups.isEmpty)
+        #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).isEmpty)
+    }
+
     @Test("T10: default-on aggregate does not reseed blobs older than explicit clear")
     func testDefaultOnAggregateHonorsClearTombstone() throws {
         let (url, context) = self.makeContext()

--- a/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
@@ -124,6 +124,43 @@ struct CWLSeedTests {
         #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).count == 1)
     }
 
+    @Test("T10: default-on aggregate backfills blobs when ledger is partially populated")
+    func testDefaultOnAggregateBackfillsPartialLedger() throws {
+        let (url, context) = self.makeContext()
+        defer { ModelContainerFactory.deleteStoreFiles(at: url) }
+
+        let asOf = try #require(CostLedgerService.utcDayKeyFormatter.date(from: "2026-05-28"))
+        try CostLedgerService.upsertDayPoint(
+            deviceID: "dev-A",
+            providerID: "codex",
+            dayKey: "2026-05-28",
+            costUSD: 5.0,
+            totalTokens: 500,
+            isEstimated: false,
+            modelBreakdowns: [],
+            serviceBreakdowns: [],
+            lastUpdated: asOf,
+            in: context)
+        context.insert(ProviderSnapshotModel(
+            deviceID: "dev-A",
+            providerID: "claude",
+            providerName: "Claude",
+            accountEmail: nil,
+            lastUpdated: asOf,
+            costSummaryData: self.summaryBlob(daily: [self.day("2026-05-28", 6.0, 600)])))
+        try context.save()
+
+        let aggregation = try CostLedgerService.aggregateSeedingFromExistingBlobsIfNeeded(
+            windowDays: 90,
+            in: context,
+            asOf: asOf)
+
+        #expect(aggregation.totalCostUSD == 11.0)
+        #expect(aggregation.providerRollups["codex|_"]?.totalCostUSD == 5.0)
+        #expect(aggregation.providerRollups["claude|_"]?.totalCostUSD == 6.0)
+        #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).count == 2)
+    }
+
     @Test("T10: default-on aggregate does not reseed blobs older than explicit clear")
     func testDefaultOnAggregateHonorsClearTombstone() throws {
         let (url, context) = self.makeContext()

--- a/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/CWLSeedTests.swift
@@ -124,6 +124,34 @@ struct CWLSeedTests {
         #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).count == 1)
     }
 
+    @Test("T10: diagnostics aggregate seeds existing blobs before reporting")
+    func testDiagnosticsAggregateSeedsBeforeReport() throws {
+        let (url, context) = self.makeContext()
+        defer { ModelContainerFactory.deleteStoreFiles(at: url) }
+
+        let asOf = try #require(SyncCostSummary.iso8601DayKeyFormatter().date(from: "2026-05-28"))
+        context.insert(ProviderSnapshotModel(
+            deviceID: "dev-A",
+            providerID: "codex",
+            providerName: "Codex",
+            accountEmail: nil,
+            lastUpdated: asOf,
+            costSummaryData: self.summaryBlob(daily: [self.day("2026-05-28", 7.0, 700)])))
+        try context.save()
+
+        #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).isEmpty)
+
+        let aggregation = try #require(CostDiagnosticsLedgerAggregationResolver.make(
+            cwlEnabled: true,
+            cwlWindowDays: 90,
+            modelContext: context,
+            activeDeviceIDs: ["dev-A"]))
+
+        #expect(aggregation.totalCostUSD == 7.0)
+        #expect(aggregation.totalTokens == 700)
+        #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).count == 1)
+    }
+
     @Test("T10: default-on aggregate backfills blobs when ledger is partially populated")
     func testDefaultOnAggregateBackfillsPartialLedger() throws {
         let (url, context) = self.makeContext()

--- a/CodexBarMobile/CodexBarMobileTests/Storage/CWLWriterTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/CWLWriterTests.swift
@@ -210,13 +210,13 @@ struct CWLWriterTests {
 
     // MARK: - Gate (`isEnabled`)
 
-    @Test("Gate: isEnabled returns false when flag absent on a fresh UserDefaults")
-    func testGateDefaultsToFalse() throws {
+    @Test("Gate: isEnabled defaults to product default when flag is absent")
+    func testGateUsesProductDefaultWhenAbsent() throws {
         let suite = "CWLTestSuite-\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suite))
         defer { defaults.removePersistentDomain(forName: suite) }
 
-        #expect(CostLedgerService.isEnabled(userDefaults: defaults) == false)
+        #expect(CostLedgerService.isEnabled(userDefaults: defaults) == MobileSettingsDefaults.cwlEnabled)
     }
 
     @Test("Gate: isEnabled returns true when flag set")

--- a/CodexBarMobile/CodexBarMobileTests/Storage/CWLWriterTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/CWLWriterTests.swift
@@ -286,6 +286,74 @@ struct CWLWriterTests {
         }
     }
 
+    @Test("upsertFromSnapshot: clear tombstone skips old snapshots and allows newer sync")
+    func testUpsertFromSnapshotHonorsClearTombstone() throws {
+        let url = self.makeTempStoreURL()
+        defer { ModelContainerFactory.deleteStoreFiles(at: url) }
+        let container = ModelContainerFactory.makeContainer(at: url)
+        let context = ModelContext(container)
+
+        let suite = "CodexBarTests-CWLWriter-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let oldUpdate = Date(timeIntervalSince1970: 1_700_000_000)
+        let clearedAt = oldUpdate.addingTimeInterval(60)
+        let newerUpdate = clearedAt.addingTimeInterval(60)
+        defaults.set(
+            clearedAt.timeIntervalSince1970,
+            forKey: MobileSettingsKeys.cwlBlobSeedClearedAt)
+
+        func snapshot(lastUpdated: Date, cost: Double) -> ProviderUsageSnapshot {
+            ProviderUsageSnapshot(
+                providerID: "codex",
+                providerName: "Codex",
+                primary: nil,
+                secondary: nil,
+                accountEmail: nil,
+                loginMethod: nil,
+                statusMessage: nil,
+                isError: false,
+                lastUpdated: lastUpdated,
+                costSummary: SyncCostSummary(
+                    sessionCostUSD: nil,
+                    sessionTokens: nil,
+                    last30DaysCostUSD: cost,
+                    last30DaysTokens: 100,
+                    daily: [
+                        SyncDailyPoint(
+                            dayKey: "2026-05-28",
+                            costUSD: cost,
+                            totalTokens: 100,
+                            modelBreakdowns: [],
+                            serviceBreakdowns: [],
+                            isEstimated: false),
+                    ],
+                    isEstimated: false))
+        }
+
+        try CostLedgerService.upsertFromSnapshot(
+            snapshot(lastUpdated: oldUpdate, cost: 5.0),
+            deviceID: "dev-A",
+            in: context,
+            userDefaults: defaults)
+        try context.save()
+
+        #expect(try context.fetch(FetchDescriptor<DailyCostPoint>()).isEmpty)
+
+        try CostLedgerService.upsertFromSnapshot(
+            snapshot(lastUpdated: newerUpdate, cost: 6.0),
+            deviceID: "dev-A",
+            in: context,
+            userDefaults: defaults)
+        try context.save()
+
+        let rows = try context.fetch(FetchDescriptor<DailyCostPoint>())
+        #expect(rows.count == 1)
+        #expect(rows.first?.costUSD == 6.0)
+        #expect(rows.first?.lastUpdated == newerUpdate)
+    }
+
     @Test("upsertFromSnapshot: nil costSummary → no rows written")
     func testNoSummaryNoRows() throws {
         let url = self.makeTempStoreURL()

--- a/CodexBarMobile/CodexBarMobileTests/Storage/SwiftDataBridgeTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/SwiftDataBridgeTests.swift
@@ -162,6 +162,35 @@ struct SwiftDataBridgeTests {
         #expect(providers.first?.lastUpdated == self.ts2)
     }
 
+    @Test("Incremental upsert does not prune providers missing from a partial delta")
+    func testIncrementalUpsertDoesNotPruneMissingProviders() throws {
+        let container = self.makeContainer()
+        let context = ModelContext(container)
+
+        let full = self.makeSnapshot(
+            deviceID: "device-A",
+            providers: [
+                self.makeProvider(id: "codex", name: "Codex", lastUpdated: self.ts1),
+                self.makeProvider(id: "claude", name: "Claude", lastUpdated: self.ts1),
+            ],
+            timestamp: self.ts1)
+        try SwiftDataBridge.upsert(deviceSnapshots: [full], into: context)
+
+        let partialDelta = self.makeSnapshot(
+            deviceID: "device-A",
+            providers: [
+                self.makeProvider(id: "codex", name: "Codex Updated", lastUpdated: self.ts2),
+            ],
+            timestamp: self.ts2)
+        try SwiftDataBridge.upsertIncremental(deviceSnapshots: [partialDelta], into: context)
+
+        let providers = try context.fetch(FetchDescriptor<ProviderSnapshotModel>())
+        #expect(providers.count == 2)
+        let namesByID = Dictionary(uniqueKeysWithValues: providers.map { ($0.providerID, $0.providerName) })
+        #expect(namesByID["codex"] == "Codex Updated")
+        #expect(namesByID["claude"] == "Claude")
+    }
+
     @Test("Subscription metadata survives SwiftData bridge round-trip")
     func testSubscriptionMetadataRoundTrip() throws {
         let container = self.makeContainer()

--- a/CodexBarMobile/CodexBarMobileTests/Storage/SwiftDataBridgeTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/SwiftDataBridgeTests.swift
@@ -164,36 +164,103 @@ struct SwiftDataBridgeTests {
         #expect(providers.first?.lastUpdated == self.ts2)
     }
 
-    @Test("Incremental upsert does not prune providers missing from a partial delta")
-    func testIncrementalUpsertDoesNotPruneMissingProviders() throws {
+    @Test("Incremental cache mirror prunes filtered providers and their ledger rows")
+    func testIncrementalCacheMirrorPrunesMissingProvidersAndLedgerRows() throws {
         let container = self.makeContainer()
         let context = ModelContext(container)
 
+        func summary(cost: Double) -> SyncCostSummary {
+            SyncCostSummary(
+                sessionCostUSD: nil,
+                sessionTokens: nil,
+                last30DaysCostUSD: cost,
+                last30DaysTokens: 100,
+                daily: [
+                    SyncDailyPoint(
+                        dayKey: "2026-05-28",
+                        costUSD: cost,
+                        totalTokens: 100,
+                        modelBreakdowns: [],
+                        serviceBreakdowns: [],
+                        isEstimated: false),
+                ],
+                isEstimated: false)
+        }
+
+        let codex = self.makeProvider(
+            id: "codex",
+            name: "Codex",
+            email: nil,
+            lastUpdated: self.ts1,
+            costSummary: summary(cost: 1))
+        let staleClaude = self.makeProvider(
+            id: "claude",
+            name: "Claude",
+            email: "user@example.com",
+            lastUpdated: self.ts1,
+            costSummary: summary(cost: 2))
+
         let full = self.makeSnapshot(
             deviceID: "device-A",
-            providers: [
-                self.makeProvider(id: "codex", name: "Codex", lastUpdated: self.ts1),
-                self.makeProvider(id: "claude", name: "Claude", lastUpdated: self.ts1),
-            ],
+            providers: [codex, staleClaude],
             timestamp: self.ts1)
         try SwiftDataBridge.upsert(deviceSnapshots: [full], into: context)
 
-        let partialDelta = self.makeSnapshot(
+        let filteredCacheSnapshot = self.makeSnapshot(
             deviceID: "device-A",
             providers: [
-                self.makeProvider(id: "codex", name: "Codex Updated", lastUpdated: self.ts2),
+                self.makeProvider(
+                    id: "codex",
+                    name: "Codex Updated",
+                    email: nil,
+                    lastUpdated: self.ts2,
+                    costSummary: summary(cost: 1)),
             ],
             timestamp: self.ts2)
-        try SwiftDataBridge.upsertIncremental(deviceSnapshots: [partialDelta], into: context)
+        try SwiftDataBridge.upsertIncrementalCacheMirror(
+            cacheDeviceSnapshots: [filteredCacheSnapshot],
+            into: context)
 
         let providers = try context.fetch(FetchDescriptor<ProviderSnapshotModel>())
-        #expect(providers.count == 2)
-        let namesByID = Dictionary(uniqueKeysWithValues: providers.map { ($0.providerID, $0.providerName) })
-        #expect(namesByID["codex"] == "Codex Updated")
-        #expect(namesByID["claude"] == "Claude")
+        #expect(providers.count == 1)
+        #expect(providers.first?.providerID == "codex")
+        #expect(providers.first?.providerName == "Codex Updated")
+
+        let ledgerRows = try context.fetch(FetchDescriptor<DailyCostPoint>())
+        #expect(ledgerRows.count == 1)
+        #expect(ledgerRows.first?.providerID == "codex")
     }
 
-    @Test("Incremental upsert applies explicit provider deletes without pruning partial siblings")
+    @Test("Incremental cache mirror preserves devices absent from the refresh")
+    func testIncrementalCacheMirrorDoesNotPruneMissingDevices() throws {
+        let container = self.makeContainer()
+        let context = ModelContext(container)
+
+        let deviceA = self.makeSnapshot(
+            deviceID: "device-A",
+            providers: [self.makeProvider(id: "codex", name: "Codex", lastUpdated: self.ts1)],
+            timestamp: self.ts1)
+        let deviceB = self.makeSnapshot(
+            deviceID: "device-B",
+            providers: [self.makeProvider(id: "claude", name: "Claude", lastUpdated: self.ts1)],
+            timestamp: self.ts1)
+        try SwiftDataBridge.upsert(deviceSnapshots: [deviceA, deviceB], into: context)
+
+        let refreshedDeviceA = self.makeSnapshot(
+            deviceID: "device-A",
+            providers: [self.makeProvider(id: "codex", name: "Codex Updated", lastUpdated: self.ts2)],
+            timestamp: self.ts2)
+        try SwiftDataBridge.upsertIncrementalCacheMirror(
+            cacheDeviceSnapshots: [refreshedDeviceA],
+            into: context)
+
+        let devices = try context.fetch(FetchDescriptor<DeviceRecord>())
+        #expect(Set(devices.map(\.deviceID)) == ["device-A", "device-B"])
+        let providers = try context.fetch(FetchDescriptor<ProviderSnapshotModel>())
+        #expect(Set(providers.map(\.deviceID)) == ["device-A", "device-B"])
+    }
+
+    @Test("Incremental cache mirror applies explicit deletes outside included devices")
     func testIncrementalUpsertDeletesExplicitProviderRecords() throws {
         let container = self.makeContainer()
         let context = ModelContext(container)
@@ -236,21 +303,20 @@ struct SwiftDataBridgeTests {
         try CostLedgerService.upsertFromSnapshot(codex, deviceID: "device-A", in: context)
         try CostLedgerService.upsertFromSnapshot(claude, deviceID: "device-A", in: context)
 
-        let partialDelta = self.makeSnapshot(
-            deviceID: "device-A",
+        let refreshedOtherDevice = self.makeSnapshot(
+            deviceID: "device-B",
             providers: [
-                self.makeProvider(id: "codex", name: "Codex Updated", email: nil, lastUpdated: self.ts2),
+                self.makeProvider(id: "gemini", name: "Gemini", email: nil, lastUpdated: self.ts2),
             ],
             timestamp: self.ts2)
-        try SwiftDataBridge.upsertIncremental(
-            deviceSnapshots: [partialDelta],
+        try SwiftDataBridge.upsertIncrementalCacheMirror(
+            cacheDeviceSnapshots: [refreshedOtherDevice],
             deletedRecordNames: ["device-A|claude|user@example.com"],
             into: context)
 
         let providers = try context.fetch(FetchDescriptor<ProviderSnapshotModel>())
-        #expect(providers.count == 1)
-        #expect(providers.first?.providerID == "codex")
-        #expect(providers.first?.providerName == "Codex Updated")
+        #expect(providers.count == 2)
+        #expect(Set(providers.map(\.providerID)) == ["codex", "gemini"])
 
         let ledgerRows = try context.fetch(FetchDescriptor<DailyCostPoint>())
         #expect(ledgerRows.count == 1)

--- a/CodexBarMobile/CodexBarMobileTests/Storage/SwiftDataBridgeTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/SwiftDataBridgeTests.swift
@@ -257,6 +257,67 @@ struct SwiftDataBridgeTests {
         #expect(ledgerRows.first?.providerID == "codex")
     }
 
+    @Test("Full upsert prunes missing providers and their ledger rows")
+    func testFullUpsertPrunesMissingProvidersAndLedgerRows() throws {
+        let container = self.makeContainer()
+        let context = ModelContext(container)
+
+        func summary(cost: Double) -> SyncCostSummary {
+            SyncCostSummary(
+                sessionCostUSD: nil,
+                sessionTokens: nil,
+                last30DaysCostUSD: cost,
+                last30DaysTokens: 100,
+                daily: [
+                    SyncDailyPoint(
+                        dayKey: "2026-05-28",
+                        costUSD: cost,
+                        totalTokens: 100,
+                        modelBreakdowns: [],
+                        serviceBreakdowns: [],
+                        isEstimated: false),
+                ],
+                isEstimated: false)
+        }
+
+        let codex = self.makeProvider(
+            id: "codex",
+            name: "Codex",
+            email: nil,
+            lastUpdated: self.ts1,
+            costSummary: summary(cost: 1))
+        let claude = self.makeProvider(
+            id: "claude",
+            name: "Claude",
+            email: "user@example.com",
+            lastUpdated: self.ts1,
+            costSummary: summary(cost: 2))
+        let full = self.makeSnapshot(
+            deviceID: "device-A",
+            providers: [codex, claude],
+            timestamp: self.ts1)
+        try SwiftDataBridge.upsert(deviceSnapshots: [full], into: context)
+        try CostLedgerService.upsertFromSnapshot(codex, deviceID: "device-A", in: context)
+        try CostLedgerService.upsertFromSnapshot(claude, deviceID: "device-A", in: context)
+
+        let replacement = self.makeSnapshot(
+            deviceID: "device-A",
+            providers: [
+                self.makeProvider(id: "codex", name: "Codex Replay", email: nil, lastUpdated: self.ts2),
+            ],
+            timestamp: self.ts2)
+        try SwiftDataBridge.upsert(deviceSnapshots: [replacement], into: context)
+
+        let providers = try context.fetch(FetchDescriptor<ProviderSnapshotModel>())
+        #expect(providers.count == 1)
+        #expect(providers.first?.providerID == "codex")
+        #expect(providers.first?.providerName == "Codex Replay")
+
+        let ledgerRows = try context.fetch(FetchDescriptor<DailyCostPoint>())
+        #expect(ledgerRows.count == 1)
+        #expect(ledgerRows.first?.providerID == "codex")
+    }
+
     @Test("Subscription metadata survives SwiftData bridge round-trip")
     func testSubscriptionMetadataRoundTrip() throws {
         let container = self.makeContainer()

--- a/CodexBarMobile/CodexBarMobileTests/Storage/SwiftDataBridgeTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/Storage/SwiftDataBridgeTests.swift
@@ -27,6 +27,7 @@ struct SwiftDataBridgeTests {
         name: String = "Claude",
         email: String? = "user@example.com",
         lastUpdated: Date,
+        costSummary: SyncCostSummary? = nil,
         utilization: [SyncUtilizationSeries]? = nil,
         subscriptionExpiresAt: Date? = nil,
         subscriptionRenewsAt: Date? = nil,
@@ -43,6 +44,7 @@ struct SwiftDataBridgeTests {
             statusMessage: nil,
             isError: false,
             lastUpdated: lastUpdated,
+            costSummary: costSummary,
             subscriptionExpiresAt: subscriptionExpiresAt,
             subscriptionRenewsAt: subscriptionRenewsAt,
             rateWindows: [],
@@ -189,6 +191,70 @@ struct SwiftDataBridgeTests {
         let namesByID = Dictionary(uniqueKeysWithValues: providers.map { ($0.providerID, $0.providerName) })
         #expect(namesByID["codex"] == "Codex Updated")
         #expect(namesByID["claude"] == "Claude")
+    }
+
+    @Test("Incremental upsert applies explicit provider deletes without pruning partial siblings")
+    func testIncrementalUpsertDeletesExplicitProviderRecords() throws {
+        let container = self.makeContainer()
+        let context = ModelContext(container)
+
+        func summary(cost: Double) -> SyncCostSummary {
+            SyncCostSummary(
+                sessionCostUSD: nil,
+                sessionTokens: nil,
+                last30DaysCostUSD: cost,
+                last30DaysTokens: 100,
+                daily: [
+                    SyncDailyPoint(
+                        dayKey: "2026-05-28",
+                        costUSD: cost,
+                        totalTokens: 100,
+                        modelBreakdowns: [],
+                        serviceBreakdowns: [],
+                        isEstimated: false),
+                ],
+                isEstimated: false)
+        }
+
+        let codex = self.makeProvider(
+            id: "codex",
+            name: "Codex",
+            email: nil,
+            lastUpdated: self.ts1,
+            costSummary: summary(cost: 1))
+        let claude = self.makeProvider(
+            id: "claude",
+            name: "Claude",
+            email: "user@example.com",
+            lastUpdated: self.ts1,
+            costSummary: summary(cost: 2))
+        let full = self.makeSnapshot(
+            deviceID: "device-A",
+            providers: [codex, claude],
+            timestamp: self.ts1)
+        try SwiftDataBridge.upsert(deviceSnapshots: [full], into: context)
+        try CostLedgerService.upsertFromSnapshot(codex, deviceID: "device-A", in: context)
+        try CostLedgerService.upsertFromSnapshot(claude, deviceID: "device-A", in: context)
+
+        let partialDelta = self.makeSnapshot(
+            deviceID: "device-A",
+            providers: [
+                self.makeProvider(id: "codex", name: "Codex Updated", email: nil, lastUpdated: self.ts2),
+            ],
+            timestamp: self.ts2)
+        try SwiftDataBridge.upsertIncremental(
+            deviceSnapshots: [partialDelta],
+            deletedRecordNames: ["device-A|claude|user@example.com"],
+            into: context)
+
+        let providers = try context.fetch(FetchDescriptor<ProviderSnapshotModel>())
+        #expect(providers.count == 1)
+        #expect(providers.first?.providerID == "codex")
+        #expect(providers.first?.providerName == "Codex Updated")
+
+        let ledgerRows = try context.fetch(FetchDescriptor<DailyCostPoint>())
+        #expect(ledgerRows.count == 1)
+        #expect(ledgerRows.first?.providerID == "codex")
     }
 
     @Test("Subscription metadata survives SwiftData bridge round-trip")

--- a/CodexBarMobile/CodexBarMobileTests/V026RenderedTextTests.swift
+++ b/CodexBarMobile/CodexBarMobileTests/V026RenderedTextTests.swift
@@ -95,7 +95,8 @@ final class V026RenderedTextTests: XCTestCase {
             budgetUsedPercent: nil,
             updatedAt: Date())
         let line = BedrockCostCard.spendRowText(for: cost)
-        XCTAssertEqual(line, "$3.50")
+        XCTAssertTrue(line.contains("3.50"), "Spend value must appear — got: \(line)")
+        XCTAssertFalse(line.contains("/"), "Budget separator must be omitted when budget is absent — got: \(line)")
     }
 
     // MARK: - C2: Moonshot balance must display the actual dollar amount, NOT zero

--- a/CodexBarMobile/CodexBarWidgetShared/CodexBarWidgetView.swift
+++ b/CodexBarMobile/CodexBarWidgetShared/CodexBarWidgetView.swift
@@ -787,11 +787,7 @@ struct CodexBarWidgetView: View {
     }
 
     private var footerAlignment: Alignment {
-        if entry.configuration.mode == .todayCost,
-           family == .systemSmall || family == .systemMedium {
-            return .center
-        }
-        return .leading
+        .center
     }
 
     private var todayCostTokenFont: Font {

--- a/CodexBarMobile/project.yml
+++ b/CodexBarMobile/project.yml
@@ -35,7 +35,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.sync
         GENERATE_INFOPLIST_FILE: true
         MARKETING_VERSION: "1.17.0"
-        CURRENT_PROJECT_VERSION: "182"
+        CURRENT_PROJECT_VERSION: "183"
 
   CodexBarMobilePushExtension:
     type: app-extension
@@ -56,7 +56,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.mobile.pushextension
         MARKETING_VERSION: "1.17.0"
-        CURRENT_PROJECT_VERSION: "182"
+        CURRENT_PROJECT_VERSION: "183"
         DEVELOPMENT_TEAM: 3TUERHN53E
         INFOPLIST_FILE: CodexBarMobilePushExtension/Info.plist
         CODE_SIGN_ENTITLEMENTS: CodexBarMobilePushExtension/PushExtension.entitlements
@@ -82,7 +82,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.mobile.widgets
         MARKETING_VERSION: "1.17.0"
-        CURRENT_PROJECT_VERSION: "182"
+        CURRENT_PROJECT_VERSION: "183"
         DEVELOPMENT_TEAM: 3TUERHN53E
         INFOPLIST_FILE: CodexBarMobileWidgets/Info.plist
         CODE_SIGN_ENTITLEMENTS: CodexBarMobileWidgets/WidgetExtension.entitlements
@@ -107,7 +107,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.mobile
         MARKETING_VERSION: "1.17.0"
-        CURRENT_PROJECT_VERSION: "182"
+        CURRENT_PROJECT_VERSION: "183"
         DEVELOPMENT_TEAM: 3TUERHN53E
         INFOPLIST_FILE: CodexBarMobile/Info.plist
         CODE_SIGN_ENTITLEMENTS: CodexBarMobile/CodexBarMobile.entitlements

--- a/CodexBarMobile/project.yml
+++ b/CodexBarMobile/project.yml
@@ -35,7 +35,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.sync
         GENERATE_INFOPLIST_FILE: true
         MARKETING_VERSION: "1.17.0"
-        CURRENT_PROJECT_VERSION: "183"
+        CURRENT_PROJECT_VERSION: "184"
 
   CodexBarMobilePushExtension:
     type: app-extension
@@ -56,7 +56,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.mobile.pushextension
         MARKETING_VERSION: "1.17.0"
-        CURRENT_PROJECT_VERSION: "183"
+        CURRENT_PROJECT_VERSION: "184"
         DEVELOPMENT_TEAM: 3TUERHN53E
         INFOPLIST_FILE: CodexBarMobilePushExtension/Info.plist
         CODE_SIGN_ENTITLEMENTS: CodexBarMobilePushExtension/PushExtension.entitlements
@@ -82,7 +82,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.mobile.widgets
         MARKETING_VERSION: "1.17.0"
-        CURRENT_PROJECT_VERSION: "183"
+        CURRENT_PROJECT_VERSION: "184"
         DEVELOPMENT_TEAM: 3TUERHN53E
         INFOPLIST_FILE: CodexBarMobileWidgets/Info.plist
         CODE_SIGN_ENTITLEMENTS: CodexBarMobileWidgets/WidgetExtension.entitlements
@@ -107,7 +107,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.mobile
         MARKETING_VERSION: "1.17.0"
-        CURRENT_PROJECT_VERSION: "183"
+        CURRENT_PROJECT_VERSION: "184"
         DEVELOPMENT_TEAM: 3TUERHN53E
         INFOPLIST_FILE: CodexBarMobile/Info.plist
         CODE_SIGN_ENTITLEMENTS: CodexBarMobile/CodexBarMobile.entitlements

--- a/CodexBarMobile/project.yml
+++ b/CodexBarMobile/project.yml
@@ -35,7 +35,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.sync
         GENERATE_INFOPLIST_FILE: true
         MARKETING_VERSION: "1.17.0"
-        CURRENT_PROJECT_VERSION: "184"
+        CURRENT_PROJECT_VERSION: "185"
 
   CodexBarMobilePushExtension:
     type: app-extension
@@ -56,7 +56,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.mobile.pushextension
         MARKETING_VERSION: "1.17.0"
-        CURRENT_PROJECT_VERSION: "184"
+        CURRENT_PROJECT_VERSION: "185"
         DEVELOPMENT_TEAM: 3TUERHN53E
         INFOPLIST_FILE: CodexBarMobilePushExtension/Info.plist
         CODE_SIGN_ENTITLEMENTS: CodexBarMobilePushExtension/PushExtension.entitlements
@@ -82,7 +82,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.mobile.widgets
         MARKETING_VERSION: "1.17.0"
-        CURRENT_PROJECT_VERSION: "184"
+        CURRENT_PROJECT_VERSION: "185"
         DEVELOPMENT_TEAM: 3TUERHN53E
         INFOPLIST_FILE: CodexBarMobileWidgets/Info.plist
         CODE_SIGN_ENTITLEMENTS: CodexBarMobileWidgets/WidgetExtension.entitlements
@@ -107,7 +107,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.mobile
         MARKETING_VERSION: "1.17.0"
-        CURRENT_PROJECT_VERSION: "184"
+        CURRENT_PROJECT_VERSION: "185"
         DEVELOPMENT_TEAM: 3TUERHN53E
         INFOPLIST_FILE: CodexBarMobile/Info.plist
         CODE_SIGN_ENTITLEMENTS: CodexBarMobile/CodexBarMobile.entitlements


### PR DESCRIPTION
## Summary
- keep this on the iOS 1.17 line as build 183
- default Local Cost History on with a 90-day window and clarify the Cost Settings copy
- add Developer Tools -> Cost Diagnostics with summary, provider merge rules, reconciliation checks, and a Raw Sync Data handoff
- center the widget updated timestamp footer across every widget mode and family

## Verification
- python3 -m json.tool CodexBarMobile/CodexBarMobile/Localizable.xcstrings
- xcodebuild -project CodexBarMobile/CodexBarMobile.xcodeproj -scheme CodexBarMobile -destination 'platform=iOS Simulator,id=624F0D2B-C204-44BF-A979-3A7F0AAA0EF3' test -only-testing:CodexBarMobileTests
- xcodebuild -project CodexBarMobile/CodexBarMobile.xcodeproj -scheme CodexBarMobile -configuration Release -destination 'generic/platform=iOS Simulator' build