### PR TITLE
release(ios): advance 1.19.1 to build 191

### DIFF
--- a/CodexBarMobile/CHANGELOG.md
+++ b/CodexBarMobile/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the CodexBar iOS companion app will be documented in this file.
 
-## [1.19.1 (190)] — 2026-07-27 — Alibaba Token Plan and utilization history hotfixes
+## [1.19.1 (191)] — 2026-07-27 — Alibaba Token Plan and utilization history hotfixes
 
 ### Fixed
 
@@ -32,13 +32,13 @@ All notable changes to the CodexBar iOS companion app will be documented in this
   publicly released. The in-app history preserves the public 1.19.0 entry and
   adds the concise 1.19.1 hotfix above it.
 - iOS `MARKETING_VERSION`: `1.19.0` → `1.19.1`.
-- iOS `CURRENT_PROJECT_VERSION`: `189` → `190`.
+- iOS `CURRENT_PROJECT_VERSION`: `189` → `191`.
 - **App Store Connect handoff** — Build 189 is live as iOS 1.19.0 with the
   Subscription Utilization fix, but it predates the Alibaba iOS presentation
-  additions. Build 190 was archived with CloudKit Production, uploaded,
-  processed as `VALID`, and bound to the new manual-release 1.19.1 version in
-  `PREPARE_FOR_SUBMISSION`. Its concise `en-US`, `ja`, `zh-Hans`, and `zh-Hant`
-  release notes were read back exactly; no App Review submission was created.
+  additions. Build 190 was archived before the final review fixes, uploaded,
+  processed as `VALID`, and initially bound to the new manual-release 1.19.1
+  version. Build 191 supersedes it so the App Store build matches the reviewed
+  and merged source. No App Review submission was created.
 
 ---
 

--- a/CodexBarMobile/CodexBarMobile.xcodeproj/project.pbxproj
+++ b/CodexBarMobile/CodexBarMobile.xcodeproj/project.pbxproj
@@ -1246,7 +1246,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobileWidgets/WidgetExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 190;
+				CURRENT_PROJECT_VERSION = 191;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobileWidgets/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1266,7 +1266,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 190;
+				CURRENT_PROJECT_VERSION = 191;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1291,7 +1291,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobileWidgets/WidgetExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 190;
+				CURRENT_PROJECT_VERSION = 191;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobileWidgets/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1466,7 +1466,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobilePushExtension/PushExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 190;
+				CURRENT_PROJECT_VERSION = 191;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobilePushExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1488,7 +1488,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobile/CodexBarMobile.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 190;
+				CURRENT_PROJECT_VERSION = 191;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1526,7 +1526,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobile/CodexBarMobile.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 190;
+				CURRENT_PROJECT_VERSION = 191;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1562,7 +1562,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 190;
+				CURRENT_PROJECT_VERSION = 191;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1586,7 +1586,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = CodexBarMobilePushExtension/PushExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 190;
+				CURRENT_PROJECT_VERSION = 191;
 				DEVELOPMENT_TEAM = 3TUERHN53E;
 				INFOPLIST_FILE = CodexBarMobilePushExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/CodexBarMobile/Research/044-subscription-utilization-freshness-fallback.md
+++ b/CodexBarMobile/Research/044-subscription-utilization-freshness-fallback.md
@@ -110,7 +110,7 @@ The canonical 2 Mac × 2 iPhone gate applies because this changes
 cross-version rendering of already-synced utilization history. The complete
 16-case ledger, substituted evidence, and residual physical-device risks are in
 [`044/03-testing.md`](044-subscription-utilization-freshness-fallback/03-testing.md).
-Its current verdict is `substituted`: code review may complete, but build 190
+Its current verdict is `substituted`: code review may complete, but build 191
 still requires the physical four-device matrix before public iOS release.
 
 ## Release Notes Consolidation
@@ -144,13 +144,14 @@ Japanese, Simplified Chinese, and Traditional Chinese.
 - App Store Connect now reports build 189 and iOS `1.19.0` as
   `READY_FOR_SALE`. Build 189 predates the later Alibaba iOS presentation
   additions, so it is not the complete fix.
-- Archived and uploaded
+- Archived and uploaded the pre-final-review candidate
   `/tmp/CodexBarMobile-20260727-144448.xcarchive`. The app, push extension,
   widget extension, and sync extension all report `1.19.1 (190)`, and the
   archived app entitlement uses CloudKit `Production`.
 - App Store Connect processed build 190 as `VALID` and unexpired. Created the
-  manual-release `1.19.1` version, bound build 190, and read back
-  `PREPARE_FOR_SUBMISSION`.
+  manual-release `1.19.1` version, initially bound build 190, and read back
+  `PREPARE_FOR_SUBMISSION`. Build 190 predates the final code-review fixes and
+  must be superseded by build 191.
 - Updated and read back `whatsNew` for `en-US`, `ja`, `zh-Hans`, and
   `zh-Hant`; every remote value exactly matches its checked-in
   `AppStoreMetadata/1.19.1` source file. No App Review submission was created.

--- a/CodexBarMobile/Research/044-subscription-utilization-freshness-fallback/03-testing.md
+++ b/CodexBarMobile/Research/044-subscription-utilization-freshness-fallback/03-testing.md
@@ -9,16 +9,16 @@ Canonical gate: [`docs/ios-sync-compatibility-testing.md`](../../../docs/ios-syn
 All 16 old/new placements are recorded and have no simulated failure. The
 physical gate is **not complete**: this workspace has one Mac and one iOS
 Simulator, not two independent Macs and two physical iPhones with retained
-old/new signed builds. PR review and merge may proceed, but iOS build 190 must
+old/new signed builds. PR review and merge may proceed, but iOS build 191 must
 not be treated as physically release-ready until silent-push, independent-cache,
 and real CloudKit convergence are exercised on the four-device matrix.
 
 Versions represented by this hotfix matrix:
 
 - old Mac: `0.45.2.1`; new Mac: `0.45.2.2`
-- old iOS reader: `1.19.0 (188)`; new iOS reader: `1.19.1 (190)`
+- old iOS reader: `1.19.0 (188)`; new iOS reader: `1.19.1 (191)`
 - uploaded build `1.19.0 (189)` contains the same Subscription Utilization
-  selection fix as build 190, but predates the Alibaba iOS presentation changes
+  selection fix as build 191, but predates the Alibaba iOS presentation changes
 
 The Subscription Utilization fix changes only the new iOS reader's selection of
 already-synced history. It adds no Mac writer change, Shared field, CloudKit
@@ -35,7 +35,7 @@ record, or physical-device push was used.
 | S2 | The two new regressions reproduce stale `session` plus current `weekly`, and fresh 0% `session` plus non-zero `weekly`. The new reader falls back only for stale data and never treats 0% as missing. Duplicate selected series are still unioned before aggregation. | pass |
 | S3 | `CloudKitMergeTests` exercises two distinct Mac device identities, opposite freshness orders, utilization-series union, stale/idle histories, zero histories, and deterministic merge order. `DualZoneReaderTests` and `SnapshotCacheTests` cover old/new zone fallback, replay, ghost filtering, cache replacement, and multi-device retention. | pass |
 | S4 | `SyncModelTests` covers old payload decoding, legacy version keys, JSON round trips, and unknown future fields. Source diff audit confirms this hotfix does not change `Shared/`, `CloudConstants`, entitlements, schema, writer code, or payload version. | pass |
-| S5 | Complete build-190 non-UI iOS suite passed 606 tests with 0 failures. `xcodegen generate` synchronized all app, push-extension, widget, and sync-framework targets at build 190. Root lint, localization, and CI-policy gates passed. | pass |
+| S5 | Final reviewed source passed the complete simulator suite with 610 tests, 0 failures, and 4 intentional SpringBoard skips; the focused multi-account suite passed 13/13. `xcodegen generate` synchronized all app, push-extension, widget, and sync-framework targets at build 191. Root lint, localization, and CI-policy gates passed. | pass |
 | S6 | The Alibaba mixed-writer compatibility evidence remains recorded in [`043/03-testing.md`](../043-alibaba-token-plan-rate-windows/03-testing.md); the combined branch reran its merge and presentation regressions before this matrix was written. | pass |
 
 ## 2 Mac × 2 iPhone Matrix
@@ -77,7 +77,7 @@ in this one-Mac simulator environment.
 
 ## Remaining Release QA
 
-Before releasing build 190 as iOS 1.19.1, execute all
+Before releasing build 191 as iOS 1.19.1, execute all
 16 rows on two Macs and two physical iPhones. For each applicable row, retain a
 screenshot or diagnostic log showing:
 

--- a/CodexBarMobile/project.yml
+++ b/CodexBarMobile/project.yml
@@ -35,7 +35,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.sync
         GENERATE_INFOPLIST_FILE: true
         MARKETING_VERSION: "1.19.1"
-        CURRENT_PROJECT_VERSION: "190"
+        CURRENT_PROJECT_VERSION: "191"
 
   CodexBarMobilePushExtension:
     type: app-extension
@@ -56,7 +56,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.mobile.pushextension
         MARKETING_VERSION: "1.19.1"
-        CURRENT_PROJECT_VERSION: "190"
+        CURRENT_PROJECT_VERSION: "191"
         DEVELOPMENT_TEAM: 3TUERHN53E
         INFOPLIST_FILE: CodexBarMobilePushExtension/Info.plist
         CODE_SIGN_ENTITLEMENTS: CodexBarMobilePushExtension/PushExtension.entitlements
@@ -82,7 +82,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.mobile.widgets
         MARKETING_VERSION: "1.19.1"
-        CURRENT_PROJECT_VERSION: "190"
+        CURRENT_PROJECT_VERSION: "191"
         DEVELOPMENT_TEAM: 3TUERHN53E
         INFOPLIST_FILE: CodexBarMobileWidgets/Info.plist
         CODE_SIGN_ENTITLEMENTS: CodexBarMobileWidgets/WidgetExtension.entitlements
@@ -107,7 +107,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.o1xhack.codexbar.mobile
         MARKETING_VERSION: "1.19.1"
-        CURRENT_PROJECT_VERSION: "190"
+        CURRENT_PROJECT_VERSION: "191"
         DEVELOPMENT_TEAM: 3TUERHN53E
         INFOPLIST_FILE: CodexBarMobile/Info.plist
         CODE_SIGN_ENTITLEMENTS: CodexBarMobile/CodexBarMobile.entitlements


### PR DESCRIPTION
## Summary

- advance every iOS target from build 190 to 191
- supersede build 190 because it was archived before PR #62 final review fixes
- preserve 1.19.1 marketing version and concise four-locale metadata

## Verification

- final reviewed source: full simulator suite 610 passed, 0 failed, 4 intentional SpringBoard skips
- focused multi-account suite: 13 passed
- `bash Scripts/lint.sh lint`
- documentation links and generated project version parity

## Release boundary

Build 191 will replace build 190 on App Store version 1.19.1. No App Review submission is authorized.