### PR TITLE
docs(ios): record build 191 App Store handoff

### DIFF
--- a/CodexBarMobile/CHANGELOG.md
+++ b/CodexBarMobile/CHANGELOG.md
@@ -37,8 +37,11 @@ All notable changes to the CodexBar iOS companion app will be documented in this
   Subscription Utilization fix, but it predates the Alibaba iOS presentation
   additions. Build 190 was archived before the final review fixes, uploaded,
   processed as `VALID`, and initially bound to the new manual-release 1.19.1
-  version. Build 191 supersedes it so the App Store build matches the reviewed
-  and merged source. No App Review submission was created.
+  version. Build 191 was archived from the reviewed and merged source with
+  CloudKit Production, uploaded, processed as `VALID`, and bound to 1.19.1 in
+  `PREPARE_FOR_SUBMISSION`. All four localized release notes match their
+  checked-in sources exactly. Build 191 supersedes build 190; no App Review
+  submission was created.
 
 ---
 

--- a/CodexBarMobile/Research/044-subscription-utilization-freshness-fallback.md
+++ b/CodexBarMobile/Research/044-subscription-utilization-freshness-fallback.md
@@ -151,7 +151,15 @@ Japanese, Simplified Chinese, and Traditional Chinese.
 - App Store Connect processed build 190 as `VALID` and unexpired. Created the
   manual-release `1.19.1` version, initially bound build 190, and read back
   `PREPARE_FOR_SUBMISSION`. Build 190 predates the final code-review fixes and
-  must be superseded by build 191.
+  was superseded by build 191.
+- Archived and uploaded
+  `/tmp/CodexBarMobile-20260727-152526.xcarchive` from the reviewed and merged
+  source. The app, push extension, widget extension, and sync extension all
+  report `1.19.1 (191)`, and the archived app entitlement uses CloudKit
+  `Production`.
+- App Store Connect processed build 191 as `VALID` and unexpired, then bound it
+  to the manual-release `1.19.1` version in `PREPARE_FOR_SUBMISSION`. Build 191
+  now supersedes the still-valid but unbound build 190.
 - Updated and read back `whatsNew` for `en-US`, `ja`, `zh-Hans`, and
   `zh-Hant`; every remote value exactly matches its checked-in
   `AppStoreMetadata/1.19.1` source file. No App Review submission was created.

--- a/CodexBarMobile/Research/044-subscription-utilization-freshness-fallback/03-testing.md
+++ b/CodexBarMobile/Research/044-subscription-utilization-freshness-fallback/03-testing.md
@@ -37,6 +37,7 @@ record, or physical-device push was used.
 | S4 | `SyncModelTests` covers old payload decoding, legacy version keys, JSON round trips, and unknown future fields. Source diff audit confirms this hotfix does not change `Shared/`, `CloudConstants`, entitlements, schema, writer code, or payload version. | pass |
 | S5 | Final reviewed source passed the complete simulator suite with 610 tests, 0 failures, and 4 intentional SpringBoard skips; the focused multi-account suite passed 13/13. `xcodegen generate` synchronized all app, push-extension, widget, and sync-framework targets at build 191. Root lint, localization, and CI-policy gates passed. | pass |
 | S6 | The Alibaba mixed-writer compatibility evidence remains recorded in [`043/03-testing.md`](../043-alibaba-token-plan-rate-windows/03-testing.md); the combined branch reran its merge and presentation regressions before this matrix was written. | pass |
+| S7 | The reviewed and merged source produced `/tmp/CodexBarMobile-20260727-152526.xcarchive`; the app and all three embedded targets report `1.19.1 (191)`, the app carries the CloudKit `Production` entitlement, ASC processed build 191 as `VALID`, and the 1.19.1 version now binds build 191 with exact four-locale metadata readback. | pass |
 
 ## 2 Mac × 2 iPhone Matrix
 


### PR DESCRIPTION
## Summary

- record the final build 191 archive and CloudKit Production evidence
- record ASC `VALID` processing and 1.19.1 build binding
- record exact four-locale metadata readback and no-review-submission boundary

## Verification

- `node Scripts/check-documentation-links.mjs`
- `git diff --check`
- readback: 1.19.1 `PREPARE_FOR_SUBMISSION`, build 191 `VALID`, four locale matches

This is documentation-only; it does not submit iOS 1.19.1 for review.