### PR TITLE
docs: record iOS 1.19.1 App Review submission

### DIFF
--- a/CodexBarMobile/CHANGELOG.md
+++ b/CodexBarMobile/CHANGELOG.md
@@ -40,8 +40,9 @@ All notable changes to the CodexBar iOS companion app will be documented in this
   version. Build 191 was archived from the reviewed and merged source with
   CloudKit Production, uploaded, processed as `VALID`, and bound to 1.19.1 in
   `PREPARE_FOR_SUBMISSION`. All four localized release notes match their
-  checked-in sources exactly. Build 191 supersedes build 190; no App Review
-  submission was created.
+  checked-in sources exactly. Build 191 supersedes build 190 and was submitted
+  to App Review on 2026-07-27; the version and review submission both read back
+  as `WAITING_FOR_REVIEW`. Release control remains `MANUAL`.
 
 ---
 

--- a/CodexBarMobile/Research/044-subscription-utilization-freshness-fallback.md
+++ b/CodexBarMobile/Research/044-subscription-utilization-freshness-fallback.md
@@ -162,4 +162,10 @@ Japanese, Simplified Chinese, and Traditional Chinese.
   now supersedes the still-valid but unbound build 190.
 - Updated and read back `whatsNew` for `en-US`, `ja`, `zh-Hans`, and
   `zh-Hant`; every remote value exactly matches its checked-in
-  `AppStoreMetadata/1.19.1` source file. No App Review submission was created.
+  `AppStoreMetadata/1.19.1` source file.
+- Created review submission `0c68910c-aa6f-4458-b9e0-3a65dca44bd6` for
+  iOS `1.19.1` and submitted it at `2026-07-27T23:01:09.024Z`. Final API
+  readback shows both the submission and App Store version in
+  `WAITING_FOR_REVIEW`, still bound to valid, unexpired build 191.
+- Release control remains `MANUAL`; this submission does not publish the
+  version automatically after approval.


### PR DESCRIPTION
## Summary
- record the iOS 1.19.1 build 191 App Review submission
- preserve the MANUAL release-control boundary
- update the release research evidence with the ASC readback

## Verification
- App Store Connect: version and submission both `WAITING_FOR_REVIEW`
- bound build: 191, `VALID`, unexpired
- four localized release notes exactly match checked-in sources
- `git diff --check`
- `./Scripts/check_ci_policy.sh`