### PR TITLE
docs(ios): add App Store notes for 1.20.0

### DIFF
--- a/CodexBarMobile/AppStoreMetadata/1.20.0/en-US/release_notes.txt
+++ b/CodexBarMobile/AppStoreMetadata/1.20.0/en-US/release_notes.txt
@@ -1,0 +1,1 @@
+Adds Qwen Cloud, ZoomMate, xAI, and Notion AI with dedicated detail pages. See ZoomMate credit history, xAI balance and daily spend, the active Notion workspace, Claude prepaid credits, and z.ai usage across 24-hour, 7-day, and 30-day ranges. Update CodexBar on Mac to 0.47.0.1 for full support.

--- a/CodexBarMobile/AppStoreMetadata/1.20.0/ja/release_notes.txt
+++ b/CodexBarMobile/AppStoreMetadata/1.20.0/ja/release_notes.txt
@@ -1,0 +1,1 @@
+Qwen Cloud、ZoomMate、xAI、Notion AI を追加し、それぞれの詳細ページを用意しました。ZoomMate のクレジット履歴、xAI の残高と日別支出、Notion の使用中ワークスペース、Claude のプリペイドクレジット、z.ai の24時間・7日間・30日間の使用履歴を確認できます。完全なサポートを利用するには、Mac の CodexBar を 0.47.0.1 に更新してください。

--- a/CodexBarMobile/AppStoreMetadata/1.20.0/zh-Hans/release_notes.txt
+++ b/CodexBarMobile/AppStoreMetadata/1.20.0/zh-Hans/release_notes.txt
@@ -1,0 +1,1 @@
+新增 Qwen Cloud、ZoomMate、xAI 和 Notion AI，并提供各自的详情页。现在可以查看 ZoomMate 额度记录、xAI 余额与每日支出、Notion 当前工作区、Claude 预付额度，以及 z.ai 最近 24 小时、7 天和 30 天的用量。请将 Mac 上的 CodexBar 更新到 0.47.0.1 以获得完整支持。

--- a/CodexBarMobile/AppStoreMetadata/1.20.0/zh-Hant/release_notes.txt
+++ b/CodexBarMobile/AppStoreMetadata/1.20.0/zh-Hant/release_notes.txt
@@ -1,0 +1,1 @@
+新增 Qwen Cloud、ZoomMate、xAI 和 Notion AI，並提供各自的詳細資訊頁。現在可以查看 ZoomMate 額度記錄、xAI 餘額與每日支出、Notion 目前工作區、Claude 預付額度，以及 z.ai 最近 24 小時、7 天和 30 天的用量。請將 Mac 上的 CodexBar 更新到 0.47.0.1 以取得完整支援。


### PR DESCRIPTION
## Summary

Adds the four App Store Connect `whatsNew` source files for iOS 1.20.0:

- en-US
- zh-Hans
- zh-Hant
- ja

The copy matches the in-app 1.20.0 release notes and points users to Mac 0.47.0.1 for full sync support. All entries are below the ASC 4,000-character limit; i18n audit passes.