### PR TITLE
fix(release): verify fork asset names

### DIFF
--- a/Scripts/check-release-assets.sh
+++ b/Scripts/check-release-assets.sh
@@ -5,16 +5,12 @@ ROOT=$(cd "$(dirname "$0")/.." && pwd)
 source "$ROOT/Scripts/sparkle_helpers.sh"
 
 TAG=${1:-$(git describe --tags --abbrev=0)}
-ARTIFACT_PREFIX="CodexBar-macos-[A-Za-z0-9_+-]+-"
+ARTIFACT_PREFIX="CodexBar-${TAG#v}"
 
 check_assets "$TAG" "$ARTIFACT_PREFIX"
 
 VERSION=${TAG#v}
-if gh --live release view "$TAG" --json assets --jq '.assets[].name' >/dev/null 2>&1; then
-  assets=$(gh --live release view "$TAG" --json assets --jq '.assets[].name')
-else
-  assets=$(gh release view "$TAG" --json assets --jq '.assets[].name')
-fi
+assets=$(gh release view "$TAG" --repo o1xhack/CodexBar-Mobile --json assets --jq '.assets[].name')
 missing=0
 for target in \
   macos-arm64 \

--- a/Scripts/check-release-assets.sh
+++ b/Scripts/check-release-assets.sh
@@ -5,9 +5,9 @@ ROOT=$(cd "$(dirname "$0")/.." && pwd)
 source "$ROOT/Scripts/sparkle_helpers.sh"
 
 TAG=${1:-$(git describe --tags --abbrev=0)}
-ARTIFACT_PREFIX="CodexBar-${TAG#v}"
+ARTIFACT_BASENAME="CodexBar-${TAG#v}"
 
-check_assets "$TAG" "$ARTIFACT_PREFIX"
+check_assets "$TAG" "$ARTIFACT_BASENAME"
 
 VERSION=${TAG#v}
 assets=$(gh release view "$TAG" --repo o1xhack/CodexBar-Mobile --json assets --jq '.assets[].name')

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -26,7 +26,6 @@ source "$ROOT/Scripts/sparkle_helpers.sh"
 APPCAST="$ROOT/appcast.xml"
 APP_NAME="CodexBar"
 RELEASE_ASSET_BASENAME="${APP_NAME}-${MARKETING_VERSION}-mobile.${MOBILE_VERSION}"
-ARTIFACT_PREFIX="CodexBar-"
 BUNDLE_ID="com.o1xhack.codexbar"
 RELEASE_BRANCH="mobile-dev"
 export CODEXBAR_RELEASE_BRANCH="$RELEASE_BRANCH"
@@ -326,7 +325,7 @@ phase2() {
     "$ROOT/Scripts/test_live_update.sh" "$PREV_TAG" "$TAG"
   fi
 
-  check_assets "$TAG" "$ARTIFACT_PREFIX"
+  check_assets "$TAG" "$RELEASE_ASSET_BASENAME"
   # Note: the release tag was already pushed in phase 1
   # (git push -f origin "$TAG"). Running `git push origin --tags` here
   # tries to push ALL local tags — including the upstream tag namespace

--- a/Scripts/sparkle_helpers.sh
+++ b/Scripts/sparkle_helpers.sh
@@ -199,12 +199,16 @@ check_assets() {
   assets=$(gh release view "$tag" --repo o1xhack/CodexBar-Mobile --json assets -q '.assets[].name' 2>&1) || {
     err "gh release view failed for $tag: $assets"
   }
-  for suffix in ".zip" ".dSYM.zip"; do
-    if ! printf "%s\n" "$assets" | grep -q "^${prefix}.*${suffix}\$"; then
-      echo "MISSING: ${prefix}*${suffix}" >&2
-      missing=1
-    fi
-  done
+  if ! printf "%s\n" "$assets" \
+    | grep -E "^${prefix}.*\.zip\$" \
+    | grep -Evq '\.dSYM\.zip$'; then
+    echo "MISSING: ${prefix}*.zip (excluding dSYM archives)" >&2
+    missing=1
+  fi
+  if ! printf "%s\n" "$assets" | grep -Eq "^${prefix}.*\.dSYM\.zip\$"; then
+    echo "MISSING: ${prefix}*.dSYM.zip" >&2
+    missing=1
+  fi
   [[ "$missing" -eq 0 ]] || err "GitHub release $tag is missing expected assets."
   echo "Release $tag assets OK ($prefix*.zip + $prefix*.dSYM.zip present)."
 }

--- a/Scripts/sparkle_helpers.sh
+++ b/Scripts/sparkle_helpers.sh
@@ -185,12 +185,12 @@ verify_appcast_entry() {
 }
 
 # ---------------------------------------------------------------------------
-# check_assets <tag> <artifact-prefix>
-#   Confirms the GitHub release at <tag> has both the .zip and .dSYM.zip
-#   assets matching <prefix>*.
+# check_assets <tag> <artifact-basename>
+#   Confirms the GitHub release at <tag> has the exact <basename>.zip and
+#   <basename>.dSYM.zip assets.
 # ---------------------------------------------------------------------------
 check_assets() {
-  local tag=$1 prefix=$2
+  local tag=$1 basename=$2
   local missing=0
   local assets
   # --repo pinned to fork explicitly. Without it, gh inspects local
@@ -199,18 +199,16 @@ check_assets() {
   assets=$(gh release view "$tag" --repo o1xhack/CodexBar-Mobile --json assets -q '.assets[].name' 2>&1) || {
     err "gh release view failed for $tag: $assets"
   }
-  if ! printf "%s\n" "$assets" \
-    | grep -E "^${prefix}.*\.zip\$" \
-    | grep -Evq '\.dSYM\.zip$'; then
-    echo "MISSING: ${prefix}*.zip (excluding dSYM archives)" >&2
+  if ! printf "%s\n" "$assets" | grep -Fxq "${basename}.zip"; then
+    echo "MISSING: ${basename}.zip" >&2
     missing=1
   fi
-  if ! printf "%s\n" "$assets" | grep -Eq "^${prefix}.*\.dSYM\.zip\$"; then
-    echo "MISSING: ${prefix}*.dSYM.zip" >&2
+  if ! printf "%s\n" "$assets" | grep -Fxq "${basename}.dSYM.zip"; then
+    echo "MISSING: ${basename}.dSYM.zip" >&2
     missing=1
   fi
   [[ "$missing" -eq 0 ]] || err "GitHub release $tag is missing expected assets."
-  echo "Release $tag assets OK ($prefix*.zip + $prefix*.dSYM.zip present)."
+  echo "Release $tag assets OK (${basename}.zip + ${basename}.dSYM.zip present)."
 }
 
 export CODEXBAR_SPARKLE_HELPERS_LOADED=1

--- a/Scripts/test_release_cli_workflow.sh
+++ b/Scripts/test_release_cli_workflow.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 WORKFLOW="$ROOT/.github/workflows/release-cli.yml"
 ASSET_CHECKER="$ROOT/Scripts/check-release-assets.sh"
+SPARKLE_HELPERS="$ROOT/Scripts/sparkle_helpers.sh"
 
 fail() {
   echo "release-cli workflow test failed: $*" >&2
@@ -12,6 +13,7 @@ fail() {
 
 [[ -f "$WORKFLOW" ]] || fail "missing $WORKFLOW"
 [[ -f "$ASSET_CHECKER" ]] || fail "missing $ASSET_CHECKER"
+[[ -f "$SPARKLE_HELPERS" ]] || fail "missing $SPARKLE_HELPERS"
 
 # The fork's signed app and dSYM use CodexBar-<full-tag-version> rather than
 # upstream's CodexBar-macos-<arch>-<version> convention.
@@ -19,6 +21,31 @@ grep -Fq 'ARTIFACT_PREFIX="CodexBar-${TAG#v}"' "$ASSET_CHECKER" || \
   fail "release asset checker must use the fork tag-derived app prefix"
 grep -Fq 'gh release view "$TAG" --repo o1xhack/CodexBar-Mobile' "$ASSET_CHECKER" || \
   fail "release asset checker must pin GitHub reads to the fork"
+
+asset_test_dir=$(mktemp -d)
+trap 'rm -rf "$asset_test_dir"' EXIT
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "%s\n" "$TEST_RELEASE_ASSETS"' \
+  > "$asset_test_dir/gh"
+chmod +x "$asset_test_dir/gh"
+
+run_asset_check() (
+  export PATH="$asset_test_dir:$PATH"
+  export TEST_RELEASE_ASSETS=$1
+  # shellcheck disable=SC1090
+  source "$SPARKLE_HELPERS"
+  check_assets "v1.2.3-mobile.4.5.6" "CodexBar-1.2.3-mobile.4.5.6"
+)
+
+both_assets=$'CodexBar-1.2.3-mobile.4.5.6.zip\nCodexBar-1.2.3-mobile.4.5.6.dSYM.zip'
+run_asset_check "$both_assets" >/dev/null || fail "complete fork assets must pass"
+if run_asset_check 'CodexBar-1.2.3-mobile.4.5.6.dSYM.zip' >/dev/null 2>&1; then
+  fail "dSYM-only release must not satisfy the app ZIP check"
+fi
+if run_asset_check 'CodexBar-1.2.3-mobile.4.5.6.zip' >/dev/null 2>&1; then
+  fail "app-only release must not satisfy the dSYM check"
+fi
 
 # Fork releases must keep producing the release assets. Only the upstream-owned
 # Homebrew dispatch is repository-gated.

--- a/Scripts/test_release_cli_workflow.sh
+++ b/Scripts/test_release_cli_workflow.sh
@@ -17,8 +17,8 @@ fail() {
 
 # The fork's signed app and dSYM use CodexBar-<full-tag-version> rather than
 # upstream's CodexBar-macos-<arch>-<version> convention.
-grep -Fq 'ARTIFACT_PREFIX="CodexBar-${TAG#v}"' "$ASSET_CHECKER" || \
-  fail "release asset checker must use the fork tag-derived app prefix"
+grep -Fq 'ARTIFACT_BASENAME="CodexBar-${TAG#v}"' "$ASSET_CHECKER" || \
+  fail "release asset checker must use the fork tag-derived app basename"
 grep -Fq 'gh release view "$TAG" --repo o1xhack/CodexBar-Mobile' "$ASSET_CHECKER" || \
   fail "release asset checker must pin GitHub reads to the fork"
 
@@ -45,6 +45,10 @@ if run_asset_check 'CodexBar-1.2.3-mobile.4.5.6.dSYM.zip' >/dev/null 2>&1; then
 fi
 if run_asset_check 'CodexBar-1.2.3-mobile.4.5.6.zip' >/dev/null 2>&1; then
   fail "app-only release must not satisfy the dSYM check"
+fi
+similar_assets=$'CodexBar-1x2x3-mobilex4x5x6-old.zip\nCodexBar-1x2x3-mobilex4x5x6-old.dSYM.zip'
+if run_asset_check "$similar_assets" >/dev/null 2>&1; then
+  fail "similarly named release assets must not satisfy exact tag checks"
 fi
 
 # Fork releases must keep producing the release assets. Only the upstream-owned

--- a/Scripts/test_release_cli_workflow.sh
+++ b/Scripts/test_release_cli_workflow.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 WORKFLOW="$ROOT/.github/workflows/release-cli.yml"
+ASSET_CHECKER="$ROOT/Scripts/check-release-assets.sh"
 
 fail() {
   echo "release-cli workflow test failed: $*" >&2
@@ -10,6 +11,14 @@ fail() {
 }
 
 [[ -f "$WORKFLOW" ]] || fail "missing $WORKFLOW"
+[[ -f "$ASSET_CHECKER" ]] || fail "missing $ASSET_CHECKER"
+
+# The fork's signed app and dSYM use CodexBar-<full-tag-version> rather than
+# upstream's CodexBar-macos-<arch>-<version> convention.
+grep -Fq 'ARTIFACT_PREFIX="CodexBar-${TAG#v}"' "$ASSET_CHECKER" || \
+  fail "release asset checker must use the fork tag-derived app prefix"
+grep -Fq 'gh release view "$TAG" --repo o1xhack/CodexBar-Mobile' "$ASSET_CHECKER" || \
+  fail "release asset checker must pin GitHub reads to the fork"
 
 # Fork releases must keep producing the release assets. Only the upstream-owned
 # Homebrew dispatch is repository-gated.


### PR DESCRIPTION
## Summary
- derive the Mac app/dSYM asset prefix from the fork release tag
- pin CLI asset reads to `o1xhack/CodexBar-Mobile`
- add a contract guard for both fork invariants

## Verification
- `bash Scripts/test_release_cli_workflow.sh`
- `bash Scripts/check-release-assets.sh v0.47.0.1-mobile.1.20.0`
- `bash Scripts/lint.sh lint`

The released tag now verifies all Mac ZIP/dSYM and CLI tarball/checksum assets successfully.