### PR TITLE
Fix release helper loading in child lint shells

### DIFF
--- a/Scripts/sparkle_helpers.sh
+++ b/Scripts/sparkle_helpers.sh
@@ -12,8 +12,11 @@
 # Side effect: prepends the SPM-downloaded Sparkle binaries (generate_appcast,
 # sign_update, BinaryDelta) to PATH so callers don't have to.
 
-# Idempotent — safe to source multiple times.
-if [[ -n "${CODEXBAR_SPARKLE_HELPERS_LOADED:-}" ]]; then
+# Idempotent — safe to source multiple times. An exported sentinel can survive
+# into a child shell even though shell functions do not; only trust it when a
+# representative helper function is actually present in this shell.
+if [[ -n "${CODEXBAR_SPARKLE_HELPERS_LOADED:-}" ]] \
+   && declare -F check_assets >/dev/null 2>&1; then
   return 0 2>/dev/null || exit 0
 fi
 
@@ -211,4 +214,4 @@ check_assets() {
   echo "Release $tag assets OK (${basename}.zip + ${basename}.dSYM.zip present)."
 }
 
-export CODEXBAR_SPARKLE_HELPERS_LOADED=1
+CODEXBAR_SPARKLE_HELPERS_LOADED=1

--- a/Scripts/test_release_cli_workflow.sh
+++ b/Scripts/test_release_cli_workflow.sh
@@ -33,6 +33,9 @@ chmod +x "$asset_test_dir/gh"
 run_asset_check() (
   export PATH="$asset_test_dir:$PATH"
   export TEST_RELEASE_ASSETS=$1
+  # A parent release shell used to export this sentinel without exporting the
+  # helper functions, causing child lint tests to skip the helper definitions.
+  export CODEXBAR_SPARKLE_HELPERS_LOADED=1
   # shellcheck disable=SC1090
   source "$SPARKLE_HELPERS"
   check_assets "v1.2.3-mobile.4.5.6" "CodexBar-1.2.3-mobile.4.5.6"


### PR DESCRIPTION
## Summary

- ignore an inherited helper sentinel when shell functions are absent
- keep the helper sentinel local to the sourcing shell
- add a regression case matching release.sh invoking lint in a child process

## Verification

- bash Scripts/test_release_cli_workflow.sh
- parent-shell sentinel reproduction passes
- Scripts/lint.sh lint

Release blocker discovered while publishing Mac 0.49.2.1.