### PR TITLE
Close out Mac 0.49.2.1 and iOS 1.21.0 release evidence

### DIFF
--- a/CodexBarMobile/Research/046-v049-upstream-sync/00-overview.md
+++ b/CodexBarMobile/Research/046-v049-upstream-sync/00-overview.md
@@ -21,7 +21,9 @@ Open issues:
 
 目标版本为 Mac `0.49.2.1 (116.1)`、iOS `1.21.0 (193)`、Sparkle version
 `116.1.1.21.0`，candidate tag `v0.49.2.1-mobile.1.21.0`。所有调研、merge、实现、测试、
-签名公证、draft release 与 review 都只在上述 upstream-sync 分支进行。
+首次签名公证、draft release 与 review 都只在上述 upstream-sync 分支进行。2026-08-17
+用户另行明确授权正式发布后，候选通过 PR 合入 `mobile-dev`，并从最终合并 commit 重新构建、
+签名、公证和发布；发布后的证据文档收口在独立 release closeout 分支完成。
 
 ## 分支证据
 
@@ -34,9 +36,11 @@ git merge --ff-only origin/mobile-dev
 git switch -c upstream-sync/v0.49.2-mobile.1.21.0
 ```
 
-分支建立后才写 Research 与实现文件。Goal 已明确确认按单版本同步方案执行。push、merge、
-published tag、live Mac release、appcast publish、TestFlight upload、App Store submission
-和 CloudKit Production deploy 均不在授权范围。
+分支建立后才写 Research 与实现文件。Goal 已明确确认按单版本同步方案执行。Goal 初始阶段
+不授权 push、merge、published tag、live Mac release、appcast publish、TestFlight upload、
+App Store submission 和 CloudKit Production deploy。2026-08-17 用户明确追加授权“Mac 先发
+release，iOS 直接打包上传”，因此随后执行 branch push、PR/merge、Mac live release/appcast
+publish 与 iOS TestFlight upload；仍未授权 App Store submission 或 CloudKit Production deploy。
 
 ## 权威基线与目标
 
@@ -146,24 +150,34 @@ iPhone、新 Mac/旧 iPhone 和两台不同 writer 的组合均要进入 16-case
 - P2：16 组合若只能 substituted，silent push、真实 CloudKit propagation、background
   convergence 与旧 iOS binary 行为仍未实测。
 
-## 授权边界
+## 初始授权边界与后续追加授权
 
-本 Goal 授权本地分支、Research、merge、代码、测试、本地 commits、签名/公证 candidate、
-GitHub draft release 与资产上传。禁止 push、merge、published tag、live release、appcast
-publish、TestFlight/App Store upload 和 CloudKit Production deploy。
+本 Goal 初始授权本地分支、Research、任务分支内 upstream merge、代码、测试、本地 commits、
+签名/公证 candidate、GitHub draft release 与资产上传；当时禁止 push、合入 `mobile-dev`、
+published tag、live release、appcast publish、TestFlight/App Store upload 和 CloudKit
+Production deploy。
 
 `Scripts/release.sh` phase 1 会创建并 force-push tag，不适用于本轮 no-push 边界；候选应
 运行 `Scripts/sign-and-notarize.sh`，再用 GitHub draft API 创建 untagged draft、上传 ZIP
 和 dSYM。`target_commitish=mobile-dev` 只是 draft 占位，最终 publish 前必须从真实 merged
 commit 重打包并替换资产。绝不运行 `release.sh --finalize`。
 
+2026-08-17 用户明确追加授权“Mac 先发 release，iOS 直接打包上传”，因此上述 no-push /
+no-live 边界在发布阶段被精确放宽：候选通过 PR 合入 `mobile-dev`，从最终 merge commit
+重新运行 `Scripts/release.sh` phase 1 和 `--finalize`，并上传 iOS TestFlight build。App Store
+review submission、公开 App Store release 与 CloudKit Production deploy 仍未授权、未执行。
+
 ## 完成结论
 
 本轮已在目标分支完成单 train 同步、Shared/iOS bridge、版本与 4 语言文案、全量回归、
-Production CloudKit `NO_DEPLOY` 审计、签名公证和 GitHub draft。代码候选 HEAD 为
-`37d46edec`；Mac `8796` tests / `851` suites、iOS xcresult `632` tests 均为 0 failure。
-GitHub draft 为
-[`untagged-d5c3a3e0664b621f548b`](https://github.com/o1xhack/CodexBar-Mobile/releases/tag/untagged-d5c3a3e0664b621f548b)，
-保持 `draft=true` / `published_at=null`。本地/远端 candidate tag、远端同步分支、appcast
-变更、live release、TestFlight 与 CloudKit deploy 均为 0；没有 merge 到 `mobile-dev`，也
-没有 push branch/tag。本轮唯一 merge 是任务分支内的 provenance merge `a75be5a4b`。
+Production CloudKit `NO_DEPLOY` 审计、签名公证、draft 和循环 review。代码候选
+`37d46edec` 的 Mac `8796` tests / `851` suites、iOS xcresult `632` tests 均为 0 failure。
+
+2026-08-17 经用户追加授权，PR
+[#89](https://github.com/o1xhack/CodexBar-Mobile/pull/89) 将同步候选合入 `mobile-dev`；发布脚本
+child-shell helper 修复经 PR [#90](https://github.com/o1xhack/CodexBar-Mobile/pull/90) 合入。
+最终发布 commit `a88b71b27` 重新构建并生成 tag `v0.49.2.1-mobile.1.21.0`；Mac
+[0.49.2.1 live release](https://github.com/o1xhack/CodexBar-Mobile/releases/tag/v0.49.2.1-mobile.1.21.0)
+及签名 appcast 已上线。iOS `1.21.0 (193)` 已 archive/upload，App Store Connect build
+`5f20e3c0-96cf-416e-ba21-8213151cdda2` 处理状态为 `VALID`。未执行 App Store review
+submission、公开 App Store 发布或 CloudKit Production deploy。

--- a/CodexBarMobile/Research/046-v049-upstream-sync/02-development.md
+++ b/CodexBarMobile/Research/046-v049-upstream-sync/02-development.md
@@ -105,4 +105,34 @@ Date: 2026-08-11
 - 创建 GitHub untagged draft `368897158`，上传 app ZIP 与 dSYM；API digest 与本地 SHA-256
   逐字一致。没有创建/推送 tag、branch，也没有修改 appcast 或发布 live release。
 
+### 2026-08-17 release closeout
+
+- 用户明确追加授权 Mac live release 与 iOS 打包上传；同步分支通过 PR
+  [#89](https://github.com/o1xhack/CodexBar-Mobile/pull/89) 合入 `mobile-dev`，merge commit
+  `c1f448339`。PR Fast Checks `32051325391` 与 conservative full Final CI `32051437233`
+  均通过。
+- 首次从 merged `mobile-dev` 运行 `Scripts/release.sh` 时，lint child shell 因继承
+  `CODEXBAR_SPARKLE_HELPERS_LOADED=1`、但未继承 shell function，出现
+  `check_assets: command not found`。修复为 sentinel 只有在 `declare -F check_assets`
+  存在时才生效，且不再 export；回归测试显式覆盖 stale inherited sentinel。修复经 PR
+  [#90](https://github.com/o1xhack/CodexBar-Mobile/pull/90) 合入，merge commit
+  `a88b71b27`；PR Fast Checks `32054938333` 与 path-selected Final CI `32055053940` 通过。
+- 从最终 merge commit 强制重建 Mac universal app；notary submission
+  `fe3ad18e-2178-46dd-ab27-4d89a8e867a5` 为 `Accepted`，staple、Gatekeeper、direct launch、
+  Production CloudKit 与 ZIP readback 均通过。phase 1 创建正式 annotated tag 和新 draft，
+  phase 2 发布 live release、验证 Sparkle signature/length，并以 commit `f6772526b` 推送
+  `appcast.xml`。
+- Mac release：
+  <https://github.com/o1xhack/CodexBar-Mobile/releases/tag/v0.49.2.1-mobile.1.21.0>；
+  Mac Release Verify run `32056443141` 通过 Gatekeeper、stapler 与 release-asset launch。
+  Release CLI run `32056443142` 的 6 个 macOS/Linux glibc/musl jobs 全部通过 build、smoke、
+  package 和 upload；release 最终包含 app/dSYM 与 6 个 CLI tarball/checksum，共 14 个 assets。
+- `xcodegen generate` 后运行 `Scripts/upload_ios_testflight.sh`；1897 Swift files 0 lint
+  violations、四语 audit 通过，archive/export/upload 均成功。archive：
+  `/tmp/CodexBarMobile-20260817-114708.xcarchive`；主 App、Push Extension、Widget Extension
+  均为 `1.21.0 (193)`，CloudKit Production。
+- App Store Connect build `5f20e3c0-96cf-416e-ba21-8213151cdda2` 已绑定 iOS `1.21.0`，
+  processing state `VALID`，`expired=false`，`usesNonExemptEncryption=false`；source、archive
+  compiled 和 ASC CDN 三层 App icon 均完成尺寸/内容回读。未提交 App Store review。
+
 禁止把 credential、token、cookie、真实账号标识或未脱敏日志写入本文。

--- a/CodexBarMobile/Research/046-v049-upstream-sync/03-testing.md
+++ b/CodexBarMobile/Research/046-v049-upstream-sync/03-testing.md
@@ -31,6 +31,11 @@ provider display/cache 与 cross-version rendering，因此
 | Signing/notarization | Developer ID `3TUERHN53E`; notary `da356aff…` Accepted; staple/distribution/direct launch pass | PASS |
 | Draft release | draft `368897158`; two uploaded assets size/digest match; no tag/no push | PASS |
 | Review | self diff + 3 independent agents + fixes/retest；本轮授权范围 P0/P1/P2/blocker 0 | PASS |
+| Merge/CI closeout | PR #89/#90；runs `32051325391`, `32051437233`, `32054938333`, `32055053940` | PASS |
+| Mac live release | tag `v0.49.2.1-mobile.1.21.0`; release/appcast readback; runs `32056443141`, `32056443142` | PASS |
+| iOS archive/upload | `/tmp/CodexBarMobile-20260817-114708.xcarchive`; `EXPORT SUCCEEDED` | PASS |
+| ASC processing | build `5f20e3c0-96cf-416e-ba21-8213151cdda2`; iOS `1.21.0 (193)` | `VALID` |
+| iOS App icon | source 1024, archive 120, ASC CDN 152；三层尺寸与视觉 readback | PASS |
 
 ## 2 Mac × 2 iPhone compatibility matrix
 
@@ -109,6 +114,29 @@ ZIP 解压复核：Mac short/build version `0.49.2.1 / 116.1.1.21.0`，CloudKit 
 Developer ID authority/team 正确；app、CLI、widget 都含 `x86_64 arm64`；app/dSYM 两组 UUID
 `A4292182…` / `527B7EE6…` 一致；无 AppleDouble entries。
 
+## Live release 与 TestFlight closeout（2026-08-17）
+
+用户在初始 Goal 后另行明确授权 live Mac release 与 iOS TestFlight upload。最终发布没有复用
+上面的 pre-merge draft artifact，而是从 merged `mobile-dev` commit `a88b71b27` 重新构建。
+
+| Item | Evidence | Result |
+|---|---|---|
+| Mac version/tag | `0.49.2.1`; Sparkle `116.1.1.21.0`; tag peel `a88b71b27` | PASS |
+| Notarization | submission `fe3ad18e-2178-46dd-ab27-4d89a8e867a5` `Accepted`; ZIP ticket validates | PASS |
+| Live app asset | 67,721,761 bytes; SHA-256 `a5b9cddf151f87f0c209e9d15a008ad8a51504be1c716aa1c384b124aa30efd0` | PASS |
+| Live dSYM asset | 52,743,103 bytes; SHA-256 `e8795a4af3e8acc88aef112a48b37e7aaf4c58c5f1d0dde08c7fe2d5b987eb07` | PASS |
+| Release | <https://github.com/o1xhack/CodexBar-Mobile/releases/tag/v0.49.2.1-mobile.1.21.0>; published `2026-08-17T18:44:38Z` | LIVE |
+| Appcast | commit `f6772526b`; remote top entry/signature/length/URL match live asset | PASS |
+| Remote release QA | Mac Release Verify `32056443141`: Gatekeeper, stapler, 5-second launch | PASS |
+| CLI release assets | Release CLI `32056443142`; 6 jobs + tarball/checksum readback; 14 total assets | PASS |
+| iOS archive | main + two extensions `1.21.0 (193)`; CloudKit Production; compiled icon readable | PASS |
+| ASC/TestFlight | build `5f20e3c0-96cf-416e-ba21-8213151cdda2`; uploaded `2026-08-17T11:51:01-07:00`; `VALID` | PASS |
+
+ASC build attributes：minimum OS `17.0`、`expired=false`、
+`usesNonExemptEncryption=false`、`iconAssetToken` present；prerelease version
+`e685d3b3-440d-4425-8cc0-4a6772ab39a6` 为 iOS `1.21.0`。本次仅上传到
+App Store Connect/TestFlight，没有提交 App Store review 或公开 App Store release。
+
 ## Residual risk
 
 本轮没有 2 台真实 Mac + 2 台真实 iPhone，因此以下风险不冒充已验证：真实 CloudKit
@@ -117,7 +145,8 @@ iPhone 独立持久化，以及 published iOS 1.20.0 binary 对新 payload 的�
 fixture、production codec、cache/reducer 与 16 masks 已覆盖确定性兼容逻辑，但不能替代上述
 系统级链路。live provider/Keychain/browser cookie 测试也未获授权、未运行。
 
-既存 `.mac-release.env` 仍指向 upstream repo/Peter signing manifest。本轮 direct fork script
-不读取它，且未运行 `Scripts/mac-release`，所以不是本轮 draft finding；未来若启用该 wrapper
-或 live finalize，应先增加 fork guard 或修正 manifest。该前置条件不改变本轮授权范围内
-`P0/P1/P2/blocker=0` 的 review 结论。
+既存 `.mac-release.env` 仍指向 upstream repo/Peter signing manifest。本轮 direct fork
+`Scripts/release.sh` / `Scripts/sign-and-notarize.sh` 不读取它，且未运行
+`Scripts/mac-release`；实际 live ZIP 的 signer、feed、public key 与 fork bundle readback 均正确。
+未来若启用 `Scripts/mac-release` wrapper，应先增加 fork guard 或修正 manifest。该前置条件
+不改变本轮 `P0/P1/P2/blocker=0` 的 review 结论。


### PR DESCRIPTION
## Summary
- record Mac 0.49.2.1 live release, notarization, Sparkle appcast, and CLI assets
- record iOS 1.21.0 (193) archive/upload and ASC VALID evidence
- update the original authorization boundary with the explicit release/upload authorization

## Validation
- git diff --check
- documentation link check
- live release/appcast/assets readback
- ASC build 193 processingState=VALID