### PR TITLE
Publish verified Mac 0.58.0.1 Sparkle feed

### DIFF
--- a/CodexBarMobile/Research/051-v058-upstream-sync/10-mac-public-release.md
+++ b/CodexBarMobile/Research/051-v058-upstream-sync/10-mac-public-release.md
@@ -1,0 +1,20 @@
+# Mac 正式发布执行记录
+
+Status: in-progress。2026-09-10 用户明确要求先正式发布 Mac，随后排查 iOS 365 天历史金额减少与同步期间 tab 卡顿；本次不上传 iOS。
+
+- 上游同步 PR：https://github.com/o1xhack/CodexBar-Mobile/pull/119
+- PR head：e8f05af2d0397e3e0492c4bf3844832ec8d0f2a3。远端 Codex review clean，1 轮，0 未解决线程，review gate 通过；Fast Checks 通过。
+- merge：9b849af3981fc849d07c5e5875ffc3941d2c18f4。签名包与该提交 Mac 输入零差异。
+- Final CI：https://github.com/o1xhack/CodexBar-Mobile/actions/runs/34533139973 ，等待最终结果。
+- Developer ID 签名、公证 Accepted、staple validate、distribution policy、隔离环境真实进程启动检查和双架构 dSYM UUID 配对全部通过。
+- Apple 公证 submission：b2dde4f3-a328-4c7f-bf57-53d377a8cb76。
+- ZIP 内版本：0.58.0.1 / 141.1.1.23.0，CodexGitCommit=e8f05af2d。
+- ZIP：76821031 bytes；SHA256 ab79844a960b5d6f805811346b6628c18b28941f26c05815ed03aa4148c1e0bb。
+- dSYM ZIP：58410818 bytes；SHA256 6d92cb5995688f5a612552d48a712c402b7c6589d76be557fb6c6dc366c4fad0。
+- make_appcast.sh 生成候选条目，sign_update --verify 成功；候选 URL 指向 v0.58.0.1-mobile.1.23.0 对应 ZIP。
+- 当前 appcast 变更仅在发布分支。必须在公开资产可下载后合并，以免提前更新 live feed。
+- 16 组合仍全部为 substituted，不能称为真实多设备 CloudKit 验证。无 schema 变更，无需 deploy。
+
+尚待：Final CI 通过、tag/draft/公开资产回读、appcast PR exact-head review 与合并、线上 feed/下载/签名验证、issue 完成回写。
+
+此前 03/09 文档中“等待凭证授权/禁止 push/无 PR”描述的是本次用户授权之前的检查点；本记录取代这些发布状态，保留历史验证事实。

--- a/appcast.xml
+++ b/appcast.xml
@@ -3,6 +3,36 @@
     <channel>
         <title>CodexBar</title>
         <item>
+            <title>0.58.0.1</title>
+            <pubDate>Thu, 10 Sep 2026 14:35:10 -0700</pubDate>
+            <link>https://raw.githubusercontent.com/o1xhack/CodexBar-Mobile/mobile-dev/appcast.xml</link>
+            <sparkle:version>141.1.1.23.0</sparkle:version>
+            <sparkle:shortVersionString>0.58.0.1</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <description><![CDATA[<h2>CodexBar 0.58.0.1-Mobile 1.23.0</h2>
+<h3>Added</h3>
+<ul>
+<li>Daily activity: inspect requests, tokens, and spending by day on Mac, with the selected time zone and clear unavailable values. iPhone receives daily request counts in the current Mac sync window.</li>
+<li>Mac menus: choose visible usage rows, session or weekly percentages, explicit reset clocks/countdowns, and compact account reset labels; hover daily cost bars for details.</li>
+<li>Mobile sync: send purchased Codex credit balances and monthly limits with their own observation times, preserving confirmed zero balances and freshness across Macs that provide observation timestamps.</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li>One upstream train: include every upstream release from v0.56.1 through v0.58.0 in Mac 0.58.0.1 (Sparkle 141.1.1.23.0). The accompanying iOS candidate is 1.24.0 (198).</li>
+<li>Cost history: retain upstream faster parsing, incremental catch-up, cross-launch report reuse, safe token aggregation, and model-pricing fixes while preserving fork estimate provenance and compatible stored history.</li>
+<li>Updates: include Sparkle 2.9.6 archive and package-signature hardening.</li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+<li>Provider data: include Codex account/reset/permission fixes, Claude credential and timestamp corrections, host-scoped Copilot Enterprise identities, Antigravity raw quota/history fixes, Kiro regional overage handling, and the remaining upstream provider improvements.</li>
+<li>iPhone balances: correctly parse Moonshot RMB/grouped/zero/negative amounts; display credits as units and preserve Ollama monthly-credit labels.</li>
+<li>Reliability: preserve cancelled-login child-process cleanup, very large timeout safety, unknown costs/counts, source time zones, Production CloudKit, fork CI, versioning, signing, and download identity.</li>
+</ul>
+<p><a href="https://github.com/o1xhack/CodexBar-Mobile/blob/mobile-dev/CHANGELOG.md">View full changelog</a></p>
+]]></description>
+            <enclosure url="https://github.com/o1xhack/CodexBar-Mobile/releases/download/v0.58.0.1-mobile.1.23.0/CodexBar-0.58.0.1-mobile.1.23.0.zip" length="76821031" type="application/octet-stream" sparkle:edSignature="StLtGfBDFs1h3XX01GNzg+TTg0uq4fwLrjIWGMmdRFcwLkrs0fvibFsX7xIRYlQnV3xcbX5Kv9DWLSTiVXJZAw=="/>
+        </item>
+        <item>
             <title>0.56.0.1</title>
             <pubDate>Sun, 30 Aug 2026 18:15:19 -0700</pubDate>
             <link>https://raw.githubusercontent.com/o1xhack/CodexBar-Mobile/mobile-dev/appcast.xml</link>
@@ -65,33 +95,6 @@
 <p><a href="https://github.com/o1xhack/CodexBar-Mobile/blob/mobile-dev/CHANGELOG.md">View full changelog</a></p>
 ]]></description>
             <enclosure url="https://github.com/o1xhack/CodexBar-Mobile/releases/download/v0.54.0.1-mobile.1.22.0/CodexBar-0.54.0.1-mobile.1.22.0.zip" length="71847424" type="application/octet-stream" sparkle:edSignature="Eocz4rv4eGIOAIdvx/QA7PIPldevkDUImpFU2amjdNMVt0sdPGdv7+wGx4eIfLytceM8YkEQknpDmD1NZRZZAA=="/>
-        </item>
-        <item>
-            <title>0.52.0.1</title>
-            <pubDate>Wed, 19 Aug 2026 13:06:02 -0700</pubDate>
-            <link>https://raw.githubusercontent.com/o1xhack/CodexBar-Mobile/mobile-dev/appcast.xml</link>
-            <sparkle:version>124.1.1.21.0</sparkle:version>
-            <sparkle:shortVersionString>0.52.0.1</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <description><![CDATA[<h2>CodexBar 0.52.0.1-Mobile 1.21.0</h2>
-<h3>Added</h3>
-<ul>
-<li>Upstream Mac: include provider accent colors, configurable workday ticks, Claude model-scoped weekly widget rows, Cursor local-session auth, Kiro re-authentication, Codex project/session spend breakdowns, and every provider/CLI improvement through upstream v0.52.0.</li>
-</ul>
-<h3>Changed</h3>
-<ul>
-<li>Fork release: combine upstream v0.49.3-v0.52.0 into Mac <code>0.52.0.1</code> (<code>124.1.1.21.0</code> Sparkle build) and the existing, not-yet-public iOS <code>1.21.0</code> release train.</li>
-<li>Mobile sync lifecycle: start and stop the Mac-to-iPhone observer from the app delegate after upstream removed the hidden SwiftUI keepalive window, preserving continuous publication without the Mission Control footprint.</li>
-<li>Cost pricing: retain fork fallback estimates for unknown OpenAI and Claude families while isolating provider-qualified routes so DeepSeek, Kimi, and OpenCode models cannot inherit OpenAI prices.</li>
-</ul>
-<h3>Fixed</h3>
-<ul>
-<li>Fork integration: preserve Production CloudKit, Mobile/fleet sync isolation, collision-safe versioning, signing, appcast, fork CI policy, parser cache invalidation, and published release history while incorporating all upstream fixes through v0.52.0.</li>
-<li>Background security and reliability: absorb upstream non-interactive Keychain access, bounded PTY/RPC teardown, Settings lifecycle, cache retention, packaged CLI resources, checksum, and launch-smoke corrections.</li>
-</ul>
-<p><a href="https://github.com/o1xhack/CodexBar-Mobile/blob/mobile-dev/CHANGELOG.md">View full changelog</a></p>
-]]></description>
-            <enclosure url="https://github.com/o1xhack/CodexBar-Mobile/releases/download/v0.52.0.1-mobile.1.21.0/CodexBar-0.52.0.1-mobile.1.21.0.zip" length="69578358" type="application/octet-stream" sparkle:edSignature="wD8GDsykaQNILwVKFgP/782cGXLsEunsNY5/zf6XUsNzIhsSFfD+CX7vJuhKJmzi1dA0j/mH8Vfk8wFkKwLfBA=="/>
         </item>
         <item>
             <title>0.14.0</title>


### PR DESCRIPTION
Prepares the Sparkle feed for the signed and notarized Mac 0.58.0.1 universal ZIP. Version 141.1.1.23.0, enclosure length 76821031, and EdDSA signature match the local archive; signature verification, Apple notarization, stapling, distribution policy, launch smoke and dSYM pairing passed.

Do not merge until the Mac release assets are public and downloadable, PR #119 Final CI passes, and this exact head receives clean Codex review. The feed stays unchanged on mobile-dev until those gates pass. Includes release provenance in Research/051/10; iOS remains unshipped.
