### PR TITLE
docs: allow independent TestFlight beta uploads

### DIFF
--- a/.agents/skills/codexbar-git-workflow/SKILL.md
+++ b/.agents/skills/codexbar-git-workflow/SKILL.md
@@ -143,9 +143,9 @@ fork-owned invariant is documented in `docs/ci-policy.md`:
 
 Code review may therefore finish before heavy CI exists on the PR. PR Fast
 Checks and Codex Code Review are independent gates: a green check run never
-means review is complete. After merge, check Final CI before release; a failure
-is fixed forward and release remains blocked until the relevant final gate
-passes.
+means review is complete. After merge, check Final CI before public release; a failure
+is fixed forward and public release remains blocked until the relevant final gate
+passes. TestFlight beta uploads are independent of this remote CI gate.
 
 After pushing or opening a PR, check status from GitHub, not memory:
 
@@ -195,8 +195,21 @@ Revised approach: <what will be redesigned or rewritten>
 ```
 
 For release/upstream-sync work, **merge, tag creation, Mac live release,
-appcast publication, and TestFlight upload are blocked until this PR review
-gate passes**. Review-fix and closeout PRs are not exceptions.
+and appcast publication are blocked until this PR review gate passes**.
+Review-fix and closeout PR merges are not exceptions.
+
+## Independent TestFlight Beta Uploads
+
+When the user authorizes TestFlight, upload directly from the task branch if needed.
+A PR, completed Codex review, merge to mobile-dev, and remote CI completion are
+not prerequisites. Do not create a PR solely to unlock TestFlight.
+
+Retain relevant local builds/tests, version and build-number checks, four-language
+release notes, signing, and CloudKit Production checks. Record the source commit,
+uploaded version/build, Apple processing/beta-access results, and known validation
+gaps. An upload does not authorize merging, tagging, or a public App Store release.
+If a PR exists, its review/CI workflow continues independently; beta upload does
+not mark those gates passed or waive them for a later merge.
 
 ## Todoist Handoff
 

--- a/.agents/skills/codexbar-git-workflow/SKILL.md
+++ b/.agents/skills/codexbar-git-workflow/SKILL.md
@@ -211,6 +211,15 @@ gaps. An upload does not authorize merging, tagging, or a public App Store relea
 If a PR exists, its review/CI workflow continues independently; beta upload does
 not mark those gates passed or waive them for a later merge.
 
+Before promoting a beta build to App Review/public release, verify its recorded
+archive source commit and tree against the clean reviewed release source. The
+selected ASC build must contain the exact reviewed code, resources, build settings
+and version; an unrelated clean review on a newer head is not evidence for an
+older binary. Record the archive/IPA hash and ASC build ID with that provenance.
+If review fixes change any shipped inputs, or provenance cannot be established,
+archive and upload a new build and select that build for submission. Docs-only
+follow-ups do not require a new binary when the shipped inputs are identical.
+
 ## Todoist Handoff
 
 After pushed commits for CodexBar Mobile, update Todoist if the tools are available.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,7 +193,11 @@ problem and revise the approach; do not keep stacking symptom-level patches.
 The PR comment must use the exact non-empty `Head`, `Repeated finding pattern`,
 `Root design/requirements problem`, and `Revised approach` fields documented in
 `$codexbar-git-workflow`.
-Release/tag/appcast/TestFlight work remains blocked until this gate passes.
+Merge, tag creation, and public release/appcast work remain blocked until this gate passes.
+TestFlight is an independent beta workflow: an authorized upload does not require
+a PR, a clean CR gate, a merge, or remote CI completion. Keep local build/test,
+versioning, four-language notes, signing, and CloudKit Production checks; record
+the source commit and any known beta validation gaps.
 
 For large Goals, the agent may make staged Git commits when the Goal or user
 authorizes implementation work. Do not push, merge, tag, publish a live release,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,12 @@ Merge, tag creation, and public release/appcast work remain blocked until this g
 TestFlight is an independent beta workflow: an authorized upload does not require
 a PR, a clean CR gate, a merge, or remote CI completion. Keep local build/test,
 versioning, four-language notes, signing, and CloudKit Production checks; record
-the source commit and any known beta validation gaps.
+the source commit and any known beta validation gaps. Before App Review/public
+release, verify that the selected ASC build was archived from the clean reviewed
+release code/resources/build configuration/version, using recorded source and
+artifact provenance. If review fixes changed shipped inputs or provenance is
+missing, archive/upload a new build; a later clean PR does not validate an older
+unreviewed binary.
 
 For large Goals, the agent may make staged Git commits when the Goal or user
 authorizes implementation work. Do not push, merge, tag, publish a live release,

--- a/CodexBarMobile/Research/053-ios-2-token-activity/00-summary.md
+++ b/CodexBarMobile/Research/053-ios-2-token-activity/00-summary.md
@@ -1,10 +1,10 @@
 # iOS 2.0 Token Activity
 
-Status: in-progress（本地实现完成；真机数据对账与发布gate未闭环）。
+Status: done（2.0 实现、CR、合并与 TestFlight 已完成；真实费用差额仍作为独立待验证事项）。
 
-目标：Provider 详情在 Subscription Utilization 下展示 Token Activity；Cost 的 Daily Spend 上增加跨 Provider Daily Tokens Overview；Codex Service Mix 移至 Codex 详情。
+目标：Provider 详情在 Subscription Utilization 下展示 Token Activity；Cost 的 Daily Spend 上增加总 Token 卡片，点击进入跨 Provider 热力图详情；Codex Service Mix 移至 Codex 详情。
 
-用户已确认实施。分支 `feature/ios-2-token-activity`，基线 `origin/mobile-dev` 871829af4（iOS 1.24.0 / 199）。本地候选版本 2.0.0 (200)，所有 targets 一致；200 尚未向 ASC 预占，上传前需再确认。
+用户已确认实施。分支 `feature/ios-2-token-activity`，基线 `origin/mobile-dev` 871829af4（iOS 1.24.0 / 199）。版本 2.0.0 (200)，所有 targets 一致；2026-09-11 已上传 ASC，VALID / IN_BETA_TESTING，Internal 组可用。
 
 - [设计](01-design.md)
 - [实现与代码审计](02-implementation.md)
@@ -12,6 +12,8 @@ Status: in-progress（本地实现完成；真机数据对账与发布gate未闭
 
 Mac 不改版本、不改代码：现有 Shared 日 Token、可用性、时区和服务分项已满足本轮展示。新增可空字段仅在 iOS 本地 SwiftData 表，CloudKit database 为 `.none`；无 Production schema deploy。
 
-未闭环：用户 1.24 升级前后约一万到八千的真实费用差额，尚无两台 Mac / iPhone 逐日对账结论。不能以本轮 UI、合成测试或迁移通过宣称该问题已修复。未 push、merge、tag、发布或上传 2.0。
+未闭环：用户 1.24 升级前后约一万到八千的真实费用差额，尚无两台 Mac / iPhone 逐日对账结论。不能以本轮 UI、合成测试或迁移通过宣称该问题已修复。PR #123 已合并，2.0 已上传 TestFlight；未提交 App Review 或发布 App Store。
 
-本地验证：737项单元测试通过；2项标准UI交互通过；Provider暗色大字号通过；四语言与仓库lint通过，iOS针对性lint及既有结构债务见03-testing。
+本地验证：744项单元测试通过；2项标准UI交互通过；Provider暗色大字号通过；四语言与仓库lint通过，iOS针对性lint及既有结构债务见03-testing。
+
+发布证据及本轮 TF 独立流程规则见 [04-testflight](04-testflight.md)。

--- a/CodexBarMobile/Research/053-ios-2-token-activity/01-design.md
+++ b/CodexBarMobile/Research/053-ios-2-token-activity/01-design.md
@@ -1,6 +1,6 @@
 # iOS 2.0 — Token Activity 与信息归属
 
-Status: in-progress（用户已确认，按本方案实施）。
+Status: done（已实施；最终 Cost 信息层级以末尾用户确认修订为准，2.0.0(200) 已进入 TF）。
 基线：origin/mobile-dev 871829af4，iOS 1.24.0 (199)。实施分支 feature/ios-2-token-activity。
 
 ## 用户目标与事实

--- a/CodexBarMobile/Research/053-ios-2-token-activity/02-implementation.md
+++ b/CodexBarMobile/Research/053-ios-2-token-activity/02-implementation.md
@@ -1,6 +1,6 @@
 # 实现与代码审计
 
-Status: 本地实现及针对性review完成；发布前真机与远端review gate未完成。
+Status: done（实现、六轮远端 CR、PR #123 合并与 TF 上传已完成；真机未覆盖项见03-testing）。
 
 ## 文件与数据流
 - `Models/TokenActivity.swift`：同一 reducer 供两处视图使用；ledger rollup 按账户匹配，避免再叠加当前 blob；显式空 rollup 不回退旧 blob；无费用但有 Token 的 Provider 保留。
@@ -31,4 +31,4 @@ ledger 查询仍为365天；不删除历史、不扩大保存承诺。blob fallb
 10. 关闭ledger时的365日映射也移入后台actor，避免在主线程处理整个Provider集合。
 11. ledger开启时始终读本地账本，即使来源快照暂时为空也不绕过clear墓碑回退旧blob。
 
-正式远端 PR review 尚未运行；没有 push 授权，不将本地自查写成远端review通过。
+远端 PR #123 在 b8c0c0e5e 最终 clean，全部线程已关闭，review gate 通过；已合并并上传2.0.0(200)。Code Review 后补齐 producer 午夜刷新、统一 optional/lower-bound 总数、安全账本求和与365日 padding 边界，详见03-testing与05-review-audit。

--- a/CodexBarMobile/Research/053-ios-2-token-activity/03-testing.md
+++ b/CodexBarMobile/Research/053-ios-2-token-activity/03-testing.md
@@ -1,6 +1,6 @@
 # iOS 2.0 测试与兼容证据
 
-Status: in-progress。本地 Simulator 使用合成 PreviewData，不能替代用户两台 Mac 的真实费用对账。
+Status: done（本轮本地/替代验证、CR 与 TF 已完成；以下实体设备项目仍明确未覆盖）。最新完整结果为744项单元测试、2项UI通过，见末尾“第六轮前统一数据语义”；发布结果见04-testflight。本地 Simulator 使用合成 PreviewData，不能替代用户两台 Mac 的真实费用对账。
 
 ## 环境与命令
 - 基线：871829af4；分支 feature/ios-2-token-activity。
@@ -10,8 +10,8 @@ Status: in-progress。本地 Simulator 使用合成 PreviewData，不能替代�
 - UI测试必须完整指定 `CodexBarMobileUITests/CodexBarMobileUITests/testTokenActivityOverviewScrollsAndSelectsDay` / `testProviderTokenActivityReplacesDailyList`。只指定target/method可能运行0个UI测试，不能视为通过。
 - lint：`PATH=/opt/homebrew/bin:$PATH bash Scripts/lint.sh lint`，工具复用已有lint-tools缓存。首次完整lint为2226文件零违规，四语言与source-key检查通过；重跑 `/tmp/cbm-2-lint-final.log` 退出0，同样2226文件零违规及四语言通过。
 
-## 最终本地验证
-- `/tmp/cbm-2-verified.log`：最终数据代码737 tests / 49 suites全部通过，包含旧库迁移、8项TokenActivity数据测试，以及后台worker短快照/暂缺来源时仍保留1200历史Token的断言。该次UI暴露夹具未写入ledger的问题，见下文，不把整包标为通过。
+## 初始本地验证（历史阶段，最终结果见末尾）
+- `/tmp/cbm-2-verified.log`：该阶段数据代码737 tests / 49 suites全部通过，包含旧库迁移、8项TokenActivity数据测试，以及后台worker短快照/暂缺来源时仍保留1200历史Token的断言。该次UI暴露夹具未写入ledger的问题，见下文，不把整包标为通过。
 - `/tmp/cbm-2-fixture-ui.log`：**2 UI tests / 0 failures，TEST SUCCEEDED**；xcresult `/tmp/cbm-2-build/Logs/Test/Test-CodexBarMobile-2026.09.11_13-42-11--0700.xcresult`。覆盖日期精确点选、横向滑动、回到今天、去除旧展开入口、Codex详情包含Service Mix且Cost全局不包含。
 - `/tmp/cbm-2-dark-large.log`：dark + accessibility-large，Provider横向浏览/回到今天测试通过。已检查[暗色大字号截图](evidence/provider-dark-large.png)；看到末端月份被裁切后将最后3周标签改为右对齐，最终标准字号截图验证月份完整。未声称已验证所有字号/小屏/iPad。
 - [Cost总览](evidence/cost-overview-light.png)、[Provider与Service Mix](evidence/provider-light.png)、[横向回看历史](evidence/provider-older-history.png) 均为实际Simulator合成数据截图。
@@ -31,7 +31,7 @@ UI夹具说明：`UI_TEST_PREVIEW_DATA`只注入内存快照，不写本地账�
 `git diff origin/mobile-dev -- Sources Tests CodexBarMobile/Shared version.env` 无输出；CloudConstants、记录类型/字段/索引/zone/订阅未改变。新增字段只在配置 `cloudKitDatabase: .none` 的iOS本地表。结论：本轮无需Production schema deploy，也无需Mac发新版。未执行线上schema变更。
 
 ## 16组合兼容gate
-本轮修改缓存字段及显示，gate适用。Mac old/new在本轮为同一0.58.0.1实现（无Mac差异），iPhone old=1.24.0(199)，new=2.0.0(200)本地候选。
+本轮修改缓存字段及显示，gate适用。Mac old/new在本轮为同一0.58.0.1实现（无Mac差异），iPhone old=1.24.0(199)，new=2.0.0(200)已上传TF版本。
 未对用户两台实体Mac和两台实体iPhone执行安装/降级/账户同步实验；当前证据只有本地Simulator、合成数据库与源代码审计。以下全部标为substituted，绝不等于真机通过。
 
 替代证据：A=Shared wire/CloudKit无变化代码审计；B=旧schema磁盘迁移；C=双Mac身份/重复/部分未知Token合成回归；D=既有ledger乱序、clear、来源过滤、窗口/时区与payload解码单测。剩余共同风险R=真实CloudKit投递、两独立手机缓存收敛、离线/前后台、用户历史差额、真机滚动未证明。
@@ -55,11 +55,11 @@ UI夹具说明：`UI_TEST_PREVIEW_DATA`只注入内存快照，不写本地账�
 | 15 | new | new | new | old | substituted | A/B/C/D | R；Mac两标签同二进制 |
 | 16 | new | new | new | new | substituted | A/B/C/D | R；Mac两标签同二进制 |
 
-## 发布前剩余门槛
+## 尚未覆盖的真机验证与产品边界
 - 用户两台Mac→iPhone逐日对账，解释1.24费用降低的具体来源，不能用合成测试替代。
 - 真机同步过程中的tab切换/滚动与两手机收敛验证；小屏/全部字号/Cost暗色大字号渲染仍未全覆盖（Provider暗色大字号已完成）。
 - 实施上限365天；多年历史回补尚未提供。
-- 远端PR review与发布流程未运行；本轮无push/upload/live release授权。
+- PR #123 六轮审查后 clean、已获用户授权合并与上传 TF；2.0.0(200) 为 VALID / IN_BETA_TESTING。未执行 live release 或 App Review。以上真机缺口不会被 TF 可用状态替代。
 
 ## PR #123 第一轮 CR 修复
 - Codex 在 49a8d23c0 指出：同 usage/device timestamp 的 provider catch-up publication 不会触发热力图刷新。

--- a/CodexBarMobile/Research/053-ios-2-token-activity/04-testflight.md
+++ b/CodexBarMobile/Research/053-ios-2-token-activity/04-testflight.md
@@ -1,6 +1,8 @@
 # 2.0 TestFlight 准备
 
-Status: in-review（PR #123；尚未上传）。
+Status: uploaded（2.0.0 / 200：VALID，IN_BETA_TESTING）。
+
+下文“已完成/审查与后续动作”保留历史准备过程；最终结果以末尾发布闭环为准。
 
 ## 本次授权
 用户要求完成更新说明后上传TestFlight，上传本身已授权。随后用户明确要求先完成 iOS PR / CR，分支 push 与 PR 审查现已授权。PR：https://github.com/o1xhack/CodexBar-Mobile/pull/123 。
@@ -28,3 +30,16 @@ Status: in-review（PR #123；尚未上传）。
 - 本轮 CR 修复 catch-up 刷新、未知/零、365 天补齐与完整 Token 聚合溢出边界；最新完整回归为 742 项单元测试与 2 项 UI 测试通过，详见03-testing。
 - 上传前按最终审查提交重新生成归档；本节前述 d92c5008e 及中间归档仅为历史准备证据，不可作为最终上传产物。
 - 最终 current-head clean、review gate、CI 与上传回读结果继续记录到 PR #123，避免以尚未完成的结果预填已通过。
+
+
+## 2026-09-11 发布闭环
+- 用户明确授权 merge #123 后上传 TF，并明确 TF 不以 PR/CR/merge/远端 CI 为前置条件；后续合并和公开发布 gate 保留。
+- PR #123 已 squash merge 到 mobile-dev：f9a5754583e89e33acf5582ac19fcc70aab3a2c1；与审查 head b8c0c0e5e3cbbfd924f0cecf7991f69caa4fc609 tree 完全一致。
+- 六轮 CR 最终 clean、0 unresolved，架构复盘已记录；Final CI 34657352376 success。
+- 上传归档：`/tmp/CodexBarMobile-2.0.0-200-b8c0c0e5e.xcarchive`；`/tmp/cbm-2-upload.log` 显示 EXPORT SUCCEEDED / Upload succeeded。
+- ASC app 6760216772，iOS train 2.0.0，build 200，ID 4e53fcca-dd57-45ee-b360-04a692c8f52a，processingState VALID，internalBuildState IN_BETA_TESTING。
+- Internal 组 hasAccessToAllBuilds=true；读取组 builds 确认包含200。未提交外部 Beta Review、App Review 或 live release。
+- en-US / zh-Hans / zh-Hant / ja betaBuildLocalizations 已通过 API 写入，并与版本目录四份更新说明逐字比对一致。
+- 源图及 archive 图标此前已视觉核对；本次 altool build-status 的 iconAssetToken 已在 Aside 打开，实际 Apple CDN 图标视觉正确。截图：`/Users/yuxiao/.aside/u/0/sessions/2026-09-11_19B1vTfBR0fpLH0N/tmp/cbm-2-cdn-browser.png`。
+- 新 TF 工作流同步至 AGENTS.md、codexbar-git-workflow/SKILL.md 与 RELEASE-CHECKLIST.md。仍保留本地测试、版本、四语言、签名与 Production 检查；上传不代表合并/公开发布授权。
+- 真机费用差额与实体多设备验收仍未完成，不因 TF 可用而宣称已修复。

--- a/CodexBarMobile/Research/053-ios-2-token-activity/05-review-audit.md
+++ b/CodexBarMobile/Research/053-ios-2-token-activity/05-review-audit.md
@@ -1,6 +1,6 @@
 # 第六轮前架构复盘
 
-状态：修正已实现并验证，等待最终当前提交 CR。
+状态：done。修正已实现并验证，b8c0c0e5e 已获最终 clean，PR #123 gate 通过并合并，TF 上传完成。
 
 - PR 审计：https://github.com/o1xhack/CodexBar-Mobile/pull/123#issuecomment-5641138029
 - 审计时当前 head：3b52c4539874111df0d536233de0d551ee0198f2；已完成五轮评审事件。

--- a/CodexBarMobile/Research/README.md
+++ b/CodexBarMobile/Research/README.md
@@ -17,7 +17,7 @@ This directory contains research documents for features being considered for Cod
 
 | # | Feature | Status | Blocker | File | Date |
 |---|---------|--------|---------|------|------|
-| 053 | iOS 2.0 Token Activity | `in-progress` | 真机对账、兼容与性能验收仍待验证 | [053-ios-2-token-activity/00-summary.md](053-ios-2-token-activity/00-summary.md) | 2026-09-11 |
+| 053 | iOS 2.0 Token Activity | `done` | 真机对账、兼容与性能验收仍待验证 | [053-ios-2-token-activity/00-summary.md](053-ios-2-token-activity/00-summary.md) | 2026-09-11 |
 | 001 | Daily Provider Utilization Chart | `blocked-upstream` | [upstream PR #565](https://github.com/steipete/CodexBar/pull/565) | [001-daily-utilization-chart.md](001-daily-utilization-chart.md) | 2026-03-19 |
 | 002 | Cost Share Card (One-Tap Share) | `done` | — | [002-cost-share-card.md](002-cost-share-card.md) | 2026-03-19 |
 | 008 | iOS Data Architecture Refactor (CloudKit split + view caching + local persistence) | `ready` | — | [008-ios-data-architecture-refactor.md](008-ios-data-architecture-refactor.md) | 2026-04-18 |

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -55,10 +55,13 @@
 - [ ] 每个 finding：修复并复测 → 在线程回复 commit/证据 → 明确 Resolve conversation → push → 再次 `@codex review`
 - [ ] merge 前运行 `Scripts/check_pr_review_gate.sh <pr>`：当前 head 必须收到 `Didn't find any major issues`，所有 thread（含 outdated）必须 `isResolved=true`
 - [ ] 第 5 轮后仍有新 finding：第 6 轮前停止补小洞，在 PR 写 `Codex review architecture audit`，并填写非空的 `Head`、`Repeated finding pattern`、`Root design/requirements problem`、`Revised approach` 四个字段；重审方向后再继续，audit 不能替代最终 clean review
-- [ ] 上述 gate 未通过时，禁止 merge、tag、Mac live release/appcast publish 与 TestFlight upload
+- [ ] 上述 gate 未通过时，禁止 merge、tag、Mac live release/appcast publish；TestFlight 内测上传独立于该 gate
 
 ## 7. 发布（在用户 Mac 上实跑）
-- [ ] `Scripts/check_pr_review_gate.sh <pr>` + PR CI 均通过后，才 merge sync 分支 → `mobile-dev`（release + appcast 都从 mobile-dev 出）
+
+TestFlight 是独立内测流程。用户授权上传后，不要求先创建 PR、通过 CR、merge 或等远端 CI；不得为了上传 TF 而强制创建 PR。仍完成适用的本地构建/测试、版本号、四语言说明、签名及 CloudKit Production 检查，记录 source commit、版本/build、Apple 处理与 beta 可用状态以及未验证风险。后续合并和公开发布仍执行各自 gate。
+
+- [ ] `Scripts/check_pr_review_gate.sh <pr>` + PR CI 均通过后，才 merge sync 分支 → `mobile-dev`（Mac release + appcast 从 mobile-dev 出；TestFlight 可从任务分支上传）
 - [ ] Sparkle 工具加进 PATH：`export PATH="$PWD/.build/artifacts/sparkle/Sparkle/bin:$PATH"`
 - [ ] `./Scripts/release.sh`（phase1：build + sign + notarize + draft GitHub release）
 - [ ] iOS：`xcodegen generate` → Archive（`-allowProvisioningUpdates`）→ export/upload 到 App Store Connect（TestFlight）

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -64,6 +64,7 @@ TestFlight 是独立内测流程。用户授权上传后，不要求先创建 PR
 - [ ] `Scripts/check_pr_review_gate.sh <pr>` + PR CI 均通过后，才 merge sync 分支 → `mobile-dev`（Mac release + appcast 从 mobile-dev 出；TestFlight 可从任务分支上传）
 - [ ] Sparkle 工具加进 PATH：`export PATH="$PWD/.build/artifacts/sparkle/Sparkle/bin:$PATH"`
 - [ ] `./Scripts/release.sh`（phase1：build + sign + notarize + draft GitHub release）
+- [ ] iOS 正式审核/公开发布前核对所选 ASC build 的 archive source commit/tree、archive/IPA hash 与 build ID；其代码、资源、构建配置和版本必须与已 clean review 的发布输入完全一致。若 CR 后有影响二进制的变化，或来源无法证明，重新归档上传新 build 并绑定新包；后续纯文档差异不要求重打相同二进制。
 - [ ] iOS：`xcodegen generate` → Archive（`-allowProvisioningUpdates`）→ export/upload 到 App Store Connect（TestFlight）
 - [ ] 用户 QA 通过后 → `./Scripts/release.sh --finalize`（publish draft + 生成签名 appcast + push 到 mobile-dev）
 - [ ] Mac public release 公开后，逐个找到本 train 对应的 open `upstream-sync` issue，回复正式 release URL 与完成说明，再手动选择 `Close as completed`。PR 只关联这些 issue，不用 closing keyword 提前关闭；draft release 也不关闭 issue


### PR DESCRIPTION
TestFlight beta uploads no longer require a PR, a clean Codex review, a merge, or completed remote CI. This allows an authorized beta upload directly from a task branch while preserving local build/test, version, localization, signing and Production environment checks. Merge and public-release gates remain unchanged.

Updates AGENTS.md, the Git workflow skill and the release checklist consistently, and records iOS 2.0.0 (200) as uploaded, VALID and available to the Internal group after PR #123 merged.

Validation: documentation diff check and CI policy guard passed; the uploaded build and all four beta note localizations were read back from ASC. No application code changed.
